### PR TITLE
feat(dev): Add Dockerfile and devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,59 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+    "name": "librmcs-develop",
+    "image": "qzhhhi/librmcs-develop:latest",
+    "privileged": true,
+    "mounts": [
+        {
+            "source": "/dev",
+            "target": "/dev",
+            "type": "bind"
+        },
+        {
+            "source": "/tmp/.X11-unix",
+            "target": "/tmp/.X11-unix",
+            "type": "bind"
+        },
+        {
+            "source": "${localEnv:HOME}",
+            "target": "/mnt/home",
+            "type": "bind"
+        }
+    ],
+    "onCreateCommand": "ln -sfn /mnt/home/.codex ~/.codex",
+    "postCreateCommand": "bash -c 'if [ -d ~/.codex ]; then $(ls ~/.vscode-server*/bin/*/bin/code-server* | head -n 1) --install-extension openai.chatgpt || true; fi;'",
+    "containerEnv": {
+        "DISPLAY": "${localEnv:DISPLAY}",
+        "HTTP_PROXY": "${localEnv:HTTP_PROXY}",
+        "HTTPS_PROXY": "${localEnv:HTTPS_PROXY}",
+        "NO_PROXY": "${localEnv:NO_PROXY}",
+        "http_proxy": "${localEnv:http_proxy}",
+        "https_proxy": "${localEnv:https_proxy}",
+        "no_proxy": "${localEnv:no_proxy}"
+    },
+    "runArgs": [
+        "--network=host"
+    ],
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "remote.autoForwardPorts": false
+            },
+            "extensions": [
+                // C++ language support
+                "llvm-vs-code-extensions.vscode-clangd",
+                // Python language support
+                "ms-python.vscode-pylance",
+                "ms-python.python",
+                "ms-python.debugpy",
+                // CMake language support
+                "KylinIdeTeam.cmake-intellisence",
+                // Code spell checking
+                "streetsidesoftware.code-spell-checker",
+                // Git enhancements
+                "mhutchie.git-graph"
+            ]
+        }
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 build/
 compile_commands.json
+
+.devcontainer/.zsh_history

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,99 @@
+FROM ubuntu:24.04
+
+# Use bash as default shell
+SHELL ["/bin/bash", "-c"]
+
+# Set timezone and locale
+RUN echo 'Etc/UTC' > /etc/timezone && \
+    ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV TZ=Etc/UTC
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install tools and libraries
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    # General
+    tzdata \
+    vim wget curl \
+    gnupg2 ca-certificates \
+    zsh usbutils \
+    cmake make ninja-build \
+    git sudo \
+    unzip xz-utils \
+    openssh-client \
+    # Host
+    libc6-dev gcc-14 g++-14 \
+    libusb-1.0-0-dev \
+    # Firmware (HPM SDK)
+    libmpc3 \
+    python3 python3-pip python3-venv \
+    python3-yaml python3-jinja2 \
+    # Clean
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* \
+    # Specify default gcc version
+    && dpkg-divert --divert /usr/bin/gcc.distrib --rename /usr/bin/gcc \
+    && dpkg-divert --divert /usr/bin/g++.distrib --rename /usr/bin/g++ \
+    && dpkg-divert --divert /usr/bin/cc.distrib --rename /usr/bin/cc \
+    && dpkg-divert --divert /usr/bin/c++.distrib --rename /usr/bin/c++ \
+    && dpkg-divert --divert /usr/bin/x86_64-linux-gnu-gcc.distrib --rename /usr/bin/x86_64-linux-gnu-gcc \
+    && dpkg-divert --divert /usr/bin/x86_64-linux-gnu-g++.distrib --rename /usr/bin/x86_64-linux-gnu-g++ \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 50 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 50 \
+    && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 50 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 50 \
+    && ln -sf /usr/bin/gcc-14 /usr/bin/x86_64-linux-gnu-gcc \
+    && ln -sf /usr/bin/g++-14 /usr/bin/x86_64-linux-gnu-g++
+
+# Download the latest riscv32 toolchain and expand it into /opt/riscv
+RUN wget https://github.com/riscv-collab/riscv-gnu-toolchain/releases/latest/download/riscv32-elf-ubuntu-24.04-gcc.tar.xz \
+    && tar -xvf riscv32-elf-ubuntu-24.04-gcc.tar.xz -C /opt/ \
+    && rm riscv32-elf-ubuntu-24.04-gcc.tar.xz
+ENV GNURISCV_TOOLCHAIN_PATH=/opt/riscv
+ENV PATH="${GNURISCV_TOOLCHAIN_PATH}/bin:${PATH}"
+
+# Download the latest arm-gnu-toolchain and expand it into /opt/arm-none-eabi
+RUN TOOLCHAIN_VERSION=15.2.rel1 \
+    && wget https://developer.arm.com/-/media/Files/downloads/gnu/${TOOLCHAIN_VERSION}/binrel/arm-gnu-toolchain-${TOOLCHAIN_VERSION}-x86_64-arm-none-eabi.tar.xz \
+        -O arm-gnu-toolchain.tar.xz \
+    && tar -xvf arm-gnu-toolchain.tar.xz -C /opt/ \
+    && rm arm-gnu-toolchain.tar.xz \
+    && mv /opt/arm-gnu-toolchain-${TOOLCHAIN_VERSION}-x86_64-arm-none-eabi /opt/arm-none-eabi
+ENV GNUARM_TOOLCHAIN_PATH=/opt/arm-none-eabi
+ENV PATH="${GNUARM_TOOLCHAIN_PATH}/bin:${PATH}"
+
+# Install latest clangd
+RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
+    && echo "deb https://apt.llvm.org/noble/ llvm-toolchain-noble main" > /etc/apt/sources.list.d/llvm.list \
+    && apt-get update \
+    && version=$(apt-cache search clangd- | grep clangd- | awk -F' ' '{print $1}' | sort -V | tail -1 | cut -d- -f2) \
+    && apt-get install -y --no-install-recommends clangd-$version \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* \
+    && update-alternatives --install /usr/bin/clangd clangd /usr/bin/clangd-$version 50
+
+# For CN users: optional Tsinghua mirror
+COPY <<EOF /etc/apt/sources.list.d/ubuntu.sources.cn.bak
+Types: deb
+URIs: http://mirrors.tuna.tsinghua.edu.cn/ubuntu/
+Suites: noble noble-updates noble-security
+Components: main restricted universe multiverse
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+EOF
+
+# Change user
+RUN chsh -s /bin/zsh ubuntu && \
+    echo "ubuntu ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers
+WORKDIR /home/ubuntu
+ENV USER=ubuntu
+ENV WORKDIR=/home/ubuntu
+USER ubuntu
+
+# Install oh my zsh & change theme to af-magic
+RUN sh -c "$(wget https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh -O -)" \
+    && sed -i 's/ZSH_THEME=\"[a-z0-9\\-]*\"/ZSH_THEME="af-magic"/g' ~/.zshrc \
+    && ln -s /workspaces/librmcs/.devcontainer/.zsh_history ~/.zsh_history


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 功能概述

本PR为项目添加并配置了完整的本地开发容器与 Docker 开发镜像，旨在为开发者提供标准化、可复现的交叉编译与编辑器开发环境。

## 主要改动

### 1. Dockerfile
- 基于 Ubuntu 24.04，使用 /bin/bash 作为默认 shell，设置时区为 UTC 与 UTF-8 locale，DEBIAN_FRONTEND=noninteractive。
- 安装广泛的开发工具与依赖（vim、wget、curl、zsh、cmake、make、ninja-build、git、sudo、python3 及其常用包、libusb 等）。
- 通过 dpkg-divert 与 update-alternatives 将系统默认 gcc/g++ 指向 gcc-14/g++-14。
- 下载并安装 riscv32-elf 交叉工具链（解压到 /opt/riscv），并将其 bin 加入 PATH。
- 下载并安装 ARM GNU 工具链（版本 15.2.rel1，解压并移动到 /opt/arm-none-eabi），并将其 bin 加入 PATH。
- 添加 LLVM apt 源并动态检测/安装最新版本的 clangd，设置 update-alternatives。
- 提供可选的中国镜像源配置文件（Tsinghua）。
- 切换默认用户为 ubuntu、设置工作目录 /home/ubuntu、授予无密码 sudo 权限。
- 安装 Oh My Zsh，并将主题设置为 af-magic，创建指向仓库中 .devcontainer/.zsh_history 的 zsh 历史文件符号链接。

### 2. .devcontainer/devcontainer.json
- 定义名为 "librmcs-develop" 的 devcontainer，基于镜像 qzhhhi/librmcs-develop:latest。
- 启用 privileged 模式、使用主机网络（--network=host）。
- 挂载 /dev、/tmp/.X11-unix，以及将宿主 HOME 绑定到容器的 /mnt/home。
- onCreateCommand：在容器内创建 ~/.codex 到 /mnt/home/.codex 的符号链接；postCreateCommand：尝试在 VS Code Server 环境中安装 openai.chatgpt 扩展（若存在）。
- 传递 DISPLAY 和代理相关环境变量（HTTP(S)_PROXY / NO_PROXY 的大小写形式）。
- 设置 remote.autoForwardPorts 为 false，并预装一组 VS Code 扩展（clangd、ms-python.pylance、ms-python.python、ms-python.debugpy、CMake 支持、拼写检查、git-graph）。

### 3. .gitignore
- 新增/确保忽略 compile_commands.json 和 .devcontainer/.zsh_history（以及 .vscode/、.cache/、build/ 等）。

## 审查难度
- Dockerfile：高（工具链下载/安装、系统替换/alternatives、镜像体积与缓存清理、安全与镜像可信性需关注）
- devcontainer 配置：中（镜像来源、绑定挂载与特权模式、postCreate 的扩展安装逻辑需验证）
- .gitignore：低

## 变更性质
仅添加/配置开发环境相关基础设施，不影响仓库业务代码或导出 API。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->