### PR TITLE
feat(firmware, spi): Add SPI framework and BMI088 IMU support

### DIFF
--- a/core/src/utility/assert.hpp
+++ b/core/src/utility/assert.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <source_location>
+#include <type_traits>
+#include <utility>
 
-#ifdef NDEBUG
-# include <utility>
+#ifndef NDEBUG
+# include <functional>
 #endif
 
 namespace librmcs::core::utility {
@@ -38,6 +40,18 @@ constexpr inline void assert_debug(
     (void)location;
 #else
     assert_always(condition, location);
+#endif
+}
+
+// Debug-only lazy assertion: The predicate is evaluated only in debug builds.
+template <typename Condition>
+requires std::is_nothrow_invocable_r_v<bool, Condition&&> inline void assert_debug_lazy(
+    Condition&& condition, const std::source_location& location = std::source_location::current()) {
+#ifdef NDEBUG
+    (void)condition;
+    (void)location;
+#else
+    assert_always(static_cast<bool>(std::invoke(std::forward<Condition>(condition))), location);
 #endif
 }
 

--- a/firmware/src/app.cpp
+++ b/firmware/src/app.cpp
@@ -1,5 +1,8 @@
 #include "firmware/src/app.hpp"
 #include "firmware/src/can/can.hpp"
+#include "firmware/src/gpio/gpio.hpp"
+#include "firmware/src/spi/bmi088/accel.hpp"
+#include "firmware/src/spi/bmi088/gyro.hpp"
 #include "firmware/src/usb/usb_descriptors.hpp"
 #include "firmware/src/usb/vendor.hpp"
 #include "firmware/src/utility/interrupt_lock_guard.hpp"
@@ -22,6 +25,10 @@ App::App() {
     can::can1.init();
     can::can2.init();
     can::can3.init();
+
+    spi::bmi088::accelerometer.init();
+    spi::bmi088::gyroscope.init();
+    gpio::init_bmi088_interrupts();
 
     usb::usb_descriptors.init();
     tusb_init();

--- a/firmware/src/gpio/gpio.cpp
+++ b/firmware/src/gpio/gpio.cpp
@@ -1,0 +1,65 @@
+#include "firmware/src/gpio/gpio.hpp"
+
+#include <cstdint>
+
+#include <board.h>
+#include <hpm_gpio_drv.h>
+#include <hpm_gpiom_drv.h>
+
+#include "firmware/src/spi/bmi088/accel.hpp"
+#include "firmware/src/spi/bmi088/gyro.hpp"
+
+namespace {
+
+constexpr uint8_t BMI088_INT_GYRO_PIN = 15; // PB15, active-low
+constexpr uint8_t BMI088_INT_ACCEL_PIN = 0; // PY00, active-low
+
+void configure_bmi088_int_gyro() {
+    HPM_IOC->PAD[IOC_PAD_PB15].FUNC_CTL = IOC_PB15_FUNC_CTL_GPIO_B_15;
+    gpiom_set_pin_controller(HPM_GPIOM, GPIOM_ASSIGN_GPIOB, BMI088_INT_GYRO_PIN, gpiom_soc_gpio0);
+    gpio_set_pin_input(HPM_GPIO0, GPIO_OE_GPIOB, BMI088_INT_GYRO_PIN);
+
+    gpio_config_pin_interrupt(
+        HPM_GPIO0, GPIO_DI_GPIOB, BMI088_INT_GYRO_PIN, gpio_interrupt_trigger_edge_falling);
+    gpio_clear_pin_interrupt_flag(HPM_GPIO0, GPIO_IF_GPIOB, BMI088_INT_GYRO_PIN);
+    gpio_enable_pin_interrupt(HPM_GPIO0, GPIO_IE_GPIOB, BMI088_INT_GYRO_PIN);
+    intc_m_enable_irq_with_priority(IRQn_GPIO0_B, 1);
+}
+
+void configure_bmi088_int_accel() {
+    HPM_IOC->PAD[IOC_PAD_PY00].FUNC_CTL = IOC_PY00_FUNC_CTL_GPIO_Y_00;
+    HPM_PIOC->PAD[IOC_PAD_PY00].FUNC_CTL = PIOC_PY00_FUNC_CTL_SOC_GPIO_Y_00;
+    gpiom_set_pin_controller(HPM_GPIOM, GPIOM_ASSIGN_GPIOY, BMI088_INT_ACCEL_PIN, gpiom_soc_gpio0);
+    gpio_set_pin_input(HPM_GPIO0, GPIO_OE_GPIOY, BMI088_INT_ACCEL_PIN);
+
+    gpio_config_pin_interrupt(
+        HPM_GPIO0, GPIO_DI_GPIOY, BMI088_INT_ACCEL_PIN, gpio_interrupt_trigger_edge_falling);
+    gpio_clear_pin_interrupt_flag(HPM_GPIO0, GPIO_IF_GPIOY, BMI088_INT_ACCEL_PIN);
+    gpio_enable_pin_interrupt(HPM_GPIO0, GPIO_IE_GPIOY, BMI088_INT_ACCEL_PIN);
+    intc_m_enable_irq_with_priority(IRQn_GPIO0_Y, 1);
+}
+
+} // namespace
+
+namespace librmcs::firmware::gpio {
+
+void init_bmi088_interrupts() {
+    configure_bmi088_int_gyro();
+    configure_bmi088_int_accel();
+}
+
+SDK_DECLARE_EXT_ISR_M(IRQn_GPIO0_B, gpio_bmi088_int_gyro_isr)
+void gpio_bmi088_int_gyro_isr() {
+    if (gpio_check_clear_interrupt_flag(HPM_GPIO0, GPIO_DI_GPIOB, BMI088_INT_GYRO_PIN)) {
+        spi::bmi088::gyroscope->data_ready_callback();
+    }
+}
+
+SDK_DECLARE_EXT_ISR_M(IRQn_GPIO0_Y, gpio_bmi088_int_accel_isr)
+void gpio_bmi088_int_accel_isr() {
+    if (gpio_check_clear_interrupt_flag(HPM_GPIO0, GPIO_DI_GPIOY, BMI088_INT_ACCEL_PIN)) {
+        spi::bmi088::accelerometer->data_ready_callback();
+    }
+}
+
+} // namespace librmcs::firmware::gpio

--- a/firmware/src/gpio/gpio.hpp
+++ b/firmware/src/gpio/gpio.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace librmcs::firmware::gpio {
+
+void init_bmi088_interrupts();
+
+} // namespace librmcs::firmware::gpio

--- a/firmware/src/spi/bmi088/accel.hpp
+++ b/firmware/src/spi/bmi088/accel.hpp
@@ -1,0 +1,187 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <new>
+
+#include <board.h>
+
+#include "core/include/librmcs/data/datas.hpp"
+#include "core/src/protocol/serializer.hpp"
+#include "core/src/utility/assert.hpp"
+#include "firmware/src/spi/spi.hpp"
+#include "firmware/src/usb/vendor.hpp"
+#include "firmware/src/utility/lazy.hpp"
+
+namespace librmcs::firmware::spi::bmi088 {
+
+class Accelerometer final : ISpiModule {
+public:
+    using Lazy = utility::Lazy<Accelerometer, Spi::Lazy*, ChipSelectPin>;
+
+    enum class Range : uint8_t { _3G = 0x00, _6G = 0x01, _12G = 0x02, _24G = 0x03 };
+    enum class DataRate : uint8_t {
+        _12 = 0x05,
+        _25 = 0x06,
+        _50 = 0x07,
+        _100 = 0x08,
+        _200 = 0x09,
+        _400 = 0x0A,
+        _800 = 0x0B,
+        _1600 = 0x0C
+    };
+
+    explicit Accelerometer(
+        Spi::Lazy* spi, ChipSelectPin chip_select, Range range = Range::_6G,
+        DataRate data_rate = DataRate::_1600)
+        : ISpiModule(chip_select)
+        , spi_(spi->init()) {
+
+        core::utility::assert_debug(spi_.try_lock());
+
+        auto read_blocked = [this](RegisterAddress address) {
+            spi_.transmit_receive_blocked(*this, prepare_tx_buffer_read(address, 1));
+            return static_cast<uint8_t>(spi_.rx_buffer[2]);
+        };
+        auto write_blocked = [this](RegisterAddress address, uint8_t value) {
+            spi_.transmit_receive_blocked(*this, prepare_tx_buffer_write(address, value));
+        };
+
+        constexpr int max_try_time = 3;
+        auto read_with_confirm = [&](RegisterAddress address, uint8_t value) {
+            for (int i = max_try_time; i-- > 0;) {
+                if (read_blocked(address) == value)
+                    return true;
+                board_delay_ms(1);
+            }
+            return false;
+        };
+        auto write_with_confirm = [&](RegisterAddress address, uint8_t value) {
+            for (int i = max_try_time; i-- > 0;) {
+                write_blocked(address, value);
+                board_delay_ms(1);
+                if (read_blocked(address) == value)
+                    return true;
+            }
+            return false;
+        };
+
+        // Dummy read to switch accelerometer to SPI mode.
+        read_blocked(RegisterAddress::ACC_CHIP_ID);
+        board_delay_ms(1);
+
+        // Reset all registers to reset value.
+        write_blocked(RegisterAddress::ACC_SOFTRESET, 0xB6);
+        board_delay_ms(1);
+
+        // "Who am I" check.
+        core::utility::assert_always(read_with_confirm(RegisterAddress::ACC_CHIP_ID, 0x1E));
+
+        // Enable INT1 as output pin, push-pull, active-low.
+        core::utility::assert_always(write_with_confirm(RegisterAddress::INT1_IO_CTRL, 0b00001000));
+        // Map data ready interrupt to pin INT1.
+        core::utility::assert_always(write_with_confirm(RegisterAddress::INT_MAP_DATA, 0b00000100));
+
+        // Set ODR (output data rate) = data_rate and OSR (over-sampling-ratio) = 1.
+        core::utility::assert_always(write_with_confirm(
+            RegisterAddress::ACC_CONF,
+            0x80 | (0x02 << 4) | (static_cast<uint8_t>(data_rate) << 0)));
+        // Set accelerometer range.
+        core::utility::assert_always(
+            write_with_confirm(RegisterAddress::ACC_RANGE, static_cast<uint8_t>(range)));
+
+        // Switch the accelerometer into active mode.
+        core::utility::assert_always(write_with_confirm(RegisterAddress::ACC_PWR_CONF, 0x00));
+        // Turn on the accelerometer.
+        core::utility::assert_always(write_with_confirm(RegisterAddress::ACC_PWR_CTRL, 0x04));
+        board_delay_ms(1); // Datasheet: wait >=450us after entering normal mode
+
+        spi_.unlock();
+    }
+
+    void data_ready_callback() { read(RegisterAddress::ACC_X_LSB, 6); }
+
+private:
+    enum class RegisterAddress : uint8_t {
+        ACC_SOFTRESET = 0x7E,
+        ACC_PWR_CTRL = 0x7D,
+        ACC_PWR_CONF = 0x7C,
+        ACC_SELF_TEST = 0x6D,
+        INT_MAP_DATA = 0x58,
+        INT2_IO_CTRL = 0x54,
+        INT1_IO_CTRL = 0x53,
+        ACC_RANGE = 0x41,
+        ACC_CONF = 0x40,
+        TEMP_LSB = 0x23,
+        TEMP_MSB = 0x22,
+        ACC_INT_STAT_1 = 0x1D,
+        SENSORTIME_2 = 0x1A,
+        SENSORTIME_1 = 0x19,
+        SENSORTIME_0 = 0x18,
+        ACC_Z_MSB = 0x17,
+        ACC_Z_LSB = 0x16,
+        ACC_Y_MSB = 0x15,
+        ACC_Y_LSB = 0x14,
+        ACC_X_MSB = 0x13,
+        ACC_X_LSB = 0x12,
+        ACC_STATUS = 0x03,
+        ACC_ERR_REG = 0x02,
+        ACC_CHIP_ID = 0x00
+    };
+
+    struct __attribute__((packed)) Data {
+        int16_t x;
+        int16_t y;
+        int16_t z;
+    };
+
+    bool write(RegisterAddress address, uint8_t value) {
+        if (!spi_.try_lock())
+            return false;
+
+        spi_.transmit_receive(*this, prepare_tx_buffer_write(address, value));
+        return true;
+    }
+
+    bool read(RegisterAddress address, size_t read_size) {
+        if (!spi_.try_lock())
+            return false;
+
+        spi_.transmit_receive(*this, prepare_tx_buffer_read(address, read_size));
+        return true;
+    }
+
+    void transmit_receive_completed_callback(size_t size) override {
+        core::utility::assert_debug(size == sizeof(Data) + 2);
+        auto& data = *std::launder(reinterpret_cast<Data*>(spi_.rx_buffer + 2));
+        handle_uplink(usb::vendor->serializer(), data);
+        spi_.unlock();
+    }
+
+    std::size_t prepare_tx_buffer_write(RegisterAddress address, uint8_t value) {
+        spi_.tx_buffer[0] = static_cast<std::byte>(address);
+        spi_.tx_buffer[1] = static_cast<std::byte>(value);
+        return 2;
+    }
+
+    std::size_t prepare_tx_buffer_read(RegisterAddress address, size_t read_size) {
+        spi_.tx_buffer[0] = std::byte{0x80} | static_cast<std::byte>(address);
+        std::memset(&spi_.tx_buffer[1], 0, read_size + 1);
+        return read_size + 2;
+    }
+
+    static void handle_uplink(core::protocol::Serializer& serializer, Data& data) {
+        core::utility::assert_debug(
+            serializer.write_imu_accelerometer(
+                data::AccelerometerDataView{.x = data.x, .y = data.y, .z = data.z})
+            != core::protocol::Serializer::SerializeResult::kInvalidArgument);
+    }
+
+    Spi& spi_;
+};
+
+inline Accelerometer::Lazy
+    accelerometer(&spi::spi2, ChipSelectPin{HPM_GPIO0_BASE, GPIO_DO_GPIOB, 14});
+
+} // namespace librmcs::firmware::spi::bmi088

--- a/firmware/src/spi/bmi088/gyro.hpp
+++ b/firmware/src/spi/bmi088/gyro.hpp
@@ -1,0 +1,180 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <new>
+
+#include <board.h>
+
+#include "core/include/librmcs/data/datas.hpp"
+#include "core/src/protocol/serializer.hpp"
+#include "core/src/utility/assert.hpp"
+#include "firmware/src/spi/spi.hpp"
+#include "firmware/src/usb/vendor.hpp"
+#include "firmware/src/utility/lazy.hpp"
+
+namespace librmcs::firmware::spi::bmi088 {
+
+class Gyroscope final : ISpiModule {
+public:
+    using Lazy = utility::Lazy<Gyroscope, Spi::Lazy*, ChipSelectPin>;
+
+    enum class DataRange : uint8_t {
+        _2000 = 0x00,
+        _1000 = 0x01,
+        _500 = 0x02,
+        _250 = 0x03,
+        _125 = 0x04
+    };
+    enum class DataRateAndBandwidth : uint8_t {
+        _2000_532 = 0x00,
+        _2000_230 = 0x01,
+        _1000_116 = 0x02,
+        _400_47 = 0x03,
+        _200_23 = 0x04,
+        _100_12 = 0x05,
+        _200_64 = 0x06,
+        _100_32 = 0x07
+    };
+
+    explicit Gyroscope(
+        Spi::Lazy* spi, ChipSelectPin chip_select, DataRange range = DataRange::_2000,
+        DataRateAndBandwidth rate = DataRateAndBandwidth::_2000_230)
+        : ISpiModule(chip_select)
+        , spi_(spi->init()) {
+
+        core::utility::assert_debug(spi_.try_lock());
+
+        auto read_blocked = [this](RegisterAddress address) {
+            spi_.transmit_receive_blocked(*this, prepare_tx_buffer_read(address, 1));
+            return static_cast<uint8_t>(spi_.rx_buffer[1]);
+        };
+        auto write_blocked = [this](RegisterAddress address, uint8_t value) {
+            spi_.transmit_receive_blocked(*this, prepare_tx_buffer_write(address, value));
+        };
+
+        constexpr int max_try_time = 3;
+        auto read_with_confirm = [&](RegisterAddress address, uint8_t value) {
+            for (int i = max_try_time; i-- > 0;) {
+                if (read_blocked(address) == value)
+                    return true;
+                board_delay_ms(1);
+            }
+            return false;
+        };
+        auto write_with_confirm = [&](RegisterAddress address, uint8_t value) {
+            for (int i = max_try_time; i-- > 0;) {
+                write_blocked(address, value);
+                board_delay_ms(1);
+                if (read_blocked(address) == value)
+                    return true;
+            }
+            return false;
+        };
+
+        // Reset all registers to reset value.
+        write_blocked(RegisterAddress::GYRO_SOFTRESET, 0xB6);
+        board_delay_ms(30);
+
+        // "Who am I" check.
+        core::utility::assert_always(read_with_confirm(RegisterAddress::GYRO_CHIP_ID, 0x0F));
+
+        // Enable the new data interrupt.
+        core::utility::assert_always(write_with_confirm(RegisterAddress::GYRO_INT_CTRL, 0x80));
+
+        // Set both INT3 and INT4 as push-pull, active-low, even though only INT3 is used.
+        core::utility::assert_always(
+            write_with_confirm(RegisterAddress::INT3_INT4_IO_CONF, 0b0000));
+        // Map data ready interrupt to INT3 pin.
+        core::utility::assert_always(write_with_confirm(RegisterAddress::INT3_INT4_IO_MAP, 0x01));
+
+        // Set ODR (output data rate, Hz) and filter bandwidth (Hz).
+        core::utility::assert_always(
+            write_with_confirm(RegisterAddress::GYRO_BANDWIDTH, 0x80 | static_cast<uint8_t>(rate)));
+        // Set data range.
+        core::utility::assert_always(
+            write_with_confirm(RegisterAddress::GYRO_RANGE, static_cast<uint8_t>(range)));
+
+        // Switch the main power mode into normal mode.
+        core::utility::assert_always(write_with_confirm(RegisterAddress::GYRO_LPM1, 0x00));
+
+        spi_.unlock();
+    }
+
+    void data_ready_callback() { read(RegisterAddress::RATE_X_LSB, 6); }
+
+private:
+    enum class RegisterAddress : uint8_t {
+        GYRO_SELF_TEST = 0x3C,
+        INT3_INT4_IO_MAP = 0x18,
+        INT3_INT4_IO_CONF = 0x16,
+        GYRO_INT_CTRL = 0x15,
+        GYRO_SOFTRESET = 0x14,
+        GYRO_LPM1 = 0x11,
+        GYRO_BANDWIDTH = 0x10,
+        GYRO_RANGE = 0x0F,
+        GYRO_INT_STAT_1 = 0x0A,
+        RATE_Z_MSB = 0x07,
+        RATE_Z_LSB = 0x06,
+        RATE_Y_MSB = 0x05,
+        RATE_Y_LSB = 0x04,
+        RATE_X_MSB = 0x03,
+        RATE_X_LSB = 0x02,
+        GYRO_CHIP_ID = 0x00
+    };
+
+    struct __attribute__((packed)) Data {
+        int16_t x;
+        int16_t y;
+        int16_t z;
+    };
+
+    bool write(RegisterAddress address, uint8_t value) {
+        if (!spi_.try_lock())
+            return false;
+
+        spi_.transmit_receive(*this, prepare_tx_buffer_write(address, value));
+        return true;
+    }
+
+    bool read(RegisterAddress address, size_t read_size) {
+        if (!spi_.try_lock())
+            return false;
+
+        spi_.transmit_receive(*this, prepare_tx_buffer_read(address, read_size));
+        return true;
+    }
+
+    void transmit_receive_completed_callback(size_t size) override {
+        core::utility::assert_debug(size == sizeof(Data) + 1);
+        auto& data = *std::launder(reinterpret_cast<Data*>(spi_.rx_buffer + 1));
+        handle_uplink(usb::vendor->serializer(), data);
+        spi_.unlock();
+    }
+
+    std::size_t prepare_tx_buffer_write(RegisterAddress address, uint8_t value) {
+        spi_.tx_buffer[0] = static_cast<std::byte>(address);
+        spi_.tx_buffer[1] = static_cast<std::byte>(value);
+        return 2;
+    }
+
+    std::size_t prepare_tx_buffer_read(RegisterAddress address, size_t read_size) {
+        spi_.tx_buffer[0] = std::byte{0x80} | static_cast<std::byte>(address);
+        std::memset(&spi_.tx_buffer[1], 0, read_size);
+        return read_size + 1;
+    }
+
+    static void handle_uplink(core::protocol::Serializer& serializer, Data& data) {
+        core::utility::assert_debug(
+            serializer.write_imu_gyroscope(
+                data::GyroscopeDataView{.x = data.x, .y = data.y, .z = data.z})
+            != core::protocol::Serializer::SerializeResult::kInvalidArgument);
+    }
+
+    Spi& spi_;
+};
+
+inline Gyroscope::Lazy gyroscope(&spi::spi2, ChipSelectPin{HPM_GPIO0_BASE, GPIO_DO_GPIOB, 10});
+
+} // namespace librmcs::firmware::spi::bmi088

--- a/firmware/src/spi/spi.cpp
+++ b/firmware/src/spi/spi.cpp
@@ -1,0 +1,24 @@
+#include "firmware/src/spi/spi.hpp"
+
+#include <cstdint>
+
+#include <board.h>
+#include <hpm_spi_drv.h>
+
+namespace librmcs::firmware::spi {
+
+SDK_DECLARE_EXT_ISR_M(IRQn_SPI2, spi2_isr)
+void spi2_isr() {
+    SPI_Type* base = HPM_SPI2;
+    uint32_t flags = spi_get_interrupt_status(base);
+
+    if (!flags) [[unlikely]]
+        return;
+
+    if (flags & spi_end_int)
+        spi2->transmit_receive_completed_callback();
+
+    spi_clear_interrupt_status(base, flags);
+}
+
+} // namespace librmcs::firmware::spi

--- a/firmware/src/spi/spi.hpp
+++ b/firmware/src/spi/spi.hpp
@@ -1,0 +1,175 @@
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+#include <board.h>
+#include <hpm_common.h>
+#include <hpm_gpio_drv.h>
+#include <hpm_spi_drv.h>
+
+#include "core/src/utility/assert.hpp"
+#include "core/src/utility/immovable.hpp"
+#include "firmware/src/utility/lazy.hpp"
+
+namespace librmcs::firmware::spi {
+
+struct ChipSelectPin {
+    uintptr_t gpio_base;
+    uint32_t port;
+    uint8_t pin;
+    bool active_low = true;
+};
+
+class ISpiModule {
+public:
+    friend class Spi;
+    explicit ISpiModule(ChipSelectPin chip_select_pin)
+        : chip_select_pin_(chip_select_pin) {}
+
+protected:
+    virtual void transmit_receive_completed_callback(std::size_t size) = 0;
+
+    ChipSelectPin chip_select_pin_;
+};
+
+class Spi : private core::utility::Immovable {
+public:
+    using Lazy = utility::Lazy<Spi, uintptr_t, uint32_t, uint32_t>;
+
+    explicit Spi(uintptr_t spi_base, uint32_t irq_num, uint32_t serial_clock_frequency)
+        : spi_base_(reinterpret_cast<SPI_Type*>(spi_base))
+        , irq_num_(irq_num) {
+
+        board_init_spi_pins(spi_base_);
+
+        spi_timing_config_t timing{};
+        timing.master_config.clk_src_freq_in_hz = board_init_spi_clock(spi_base_);
+        timing.master_config.sclk_freq_in_hz = serial_clock_frequency;
+        timing.master_config.cs2sclk = spi_cs2sclk_half_sclk_1;
+        timing.master_config.csht = spi_csht_half_sclk_1;
+        core::utility::assert_always(spi_master_timing_init(spi_base_, &timing) == status_success);
+
+        spi_format_config_t format{};
+        spi_master_get_default_format_config(&format);
+        format.common_config.data_len_in_bits = 8;
+        format.common_config.data_merge = false;
+        format.common_config.lsb = false;
+        format.common_config.mode = spi_master_mode;
+        format.common_config.cpol = spi_sclk_high_idle;
+        format.common_config.cpha = spi_sclk_sampling_even_clk_edges;
+        spi_format_init(spi_base_, &format);
+
+        spi_master_get_default_control_config(&control_config_);
+        control_config_.common_config.trans_mode = spi_trans_write_read_together;
+        control_config_.common_config.data_phase_fmt = spi_single_io_mode;
+        control_config_.master_config.cmd_enable = false;
+        control_config_.master_config.addr_enable = false;
+        control_config_.master_config.token_enable = false;
+
+        intc_m_enable_irq_with_priority(irq_num_, 1);
+        spi_enable_interrupt(spi_base_, spi_end_int);
+
+        core::utility::assert_debug_lazy([&]() noexcept {
+            return spi_get_tx_fifo_size(spi_base_) == kHardwareFifoSize
+                && spi_get_rx_fifo_size(spi_base_) == kHardwareFifoSize;
+        });
+    }
+
+    ~Spi() = delete;
+
+    bool locking() { return locking_.test(std::memory_order::relaxed); }
+
+    bool try_lock() { return !locking_.test_and_set(std::memory_order::relaxed); }
+
+    void transmit_receive(ISpiModule& module, std::size_t size) {
+        core::utility::assert_debug(size <= kMaxTransferSize);
+        core::utility::assert_debug_lazy(
+            [&]() noexcept { return locking() && !spi_is_active(spi_base_); });
+
+        begin_transfer(module, size);
+
+        core::utility::assert_debug(
+            spi_control_init(spi_base_, &control_config_, size, size) == status_success);
+        core::utility::assert_debug(
+            spi_write_command(spi_base_, spi_master_mode, &control_config_, nullptr)
+            == status_success);
+
+        if (size <= kHardwareFifoSize) {
+            for (size_t i = 0; i < size; i++)
+                spi_base_->DATA = static_cast<uint32_t>(tx_buffer[i]);
+        } else {
+            core::utility::assert_failed_always(); // TODO: Transfer with DMA
+        }
+    }
+
+    void transmit_receive_blocked(ISpiModule& module, std::size_t size) {
+        intc_m_disable_irq(irq_num_);
+
+        transmit_receive(module, size);
+        while (spi_is_active(spi_base_))
+            ;
+
+        finish_transfer();
+
+        intc_m_enable_irq(irq_num_);
+    }
+
+    void transmit_receive_completed_callback() {
+        // core::utility::assert_debug(module_);
+        if (auto module = finish_transfer())
+            module->transmit_receive_completed_callback(tx_rx_size_);
+    }
+
+    void unlock() {
+        core::utility::assert_debug_lazy([&]() noexcept { return locking(); });
+        locking_.clear(std::memory_order::relaxed);
+    }
+
+    static constexpr std::size_t kMaxTransferSize = HPM_L1C_CACHELINE_SIZE;
+    static constexpr std::size_t kHardwareFifoSize = 8;
+
+    alignas(HPM_L1C_CACHELINE_SIZE) std::byte tx_buffer[HPM_L1C_CACHELINE_SIZE];
+    alignas(HPM_L1C_CACHELINE_SIZE) std::byte rx_buffer[HPM_L1C_CACHELINE_SIZE];
+
+private:
+    void begin_transfer(ISpiModule& module, std::size_t size) {
+        module_ = &module;
+        tx_rx_size_ = size;
+
+        const auto& cs = module_->chip_select_pin_;
+        auto* gpio = reinterpret_cast<GPIO_Type*>(cs.gpio_base);
+        gpio_write_pin(gpio, cs.port, cs.pin, cs.active_low ? 0 : 1);
+    }
+
+    ISpiModule* finish_transfer() {
+        if (!module_)
+            return nullptr;
+
+        const auto& cs = module_->chip_select_pin_;
+        auto* gpio = reinterpret_cast<GPIO_Type*>(cs.gpio_base);
+        gpio_write_pin(gpio, cs.port, cs.pin, cs.active_low ? 1 : 0);
+
+        for (size_t i = 0; i < tx_rx_size_; i++)
+            rx_buffer[i] = static_cast<std::byte>(spi_base_->DATA);
+
+        auto module = module_;
+        module_ = nullptr;
+        return module;
+    }
+
+    SPI_Type* spi_base_;
+    uint32_t irq_num_;
+
+    std::atomic_flag locking_;
+
+    ISpiModule* module_ = nullptr;
+    size_t tx_rx_size_ = 0;
+
+    spi_control_config_t control_config_{};
+};
+
+inline constinit Spi::Lazy spi2{HPM_SPI2_BASE, IRQn_SPI2, 10'000'000}; // 10Mbps
+
+} // namespace librmcs::firmware::spi


### PR DESCRIPTION
- Add generic SPI module abstraction and SPI2 ISR-based transfer completion
- Add BMI088 accelerometer/gyroscope drivers with data-ready interrupt readout and USB uplink serialization
- Add GPIO configuration + ISRs for BMI088 INT pins and hook initialization into App startup
- Add debug-only lazy assertion helper to support expensive/conditional checks

Notes:
- SPI transfer currently supports FIFO-sized transactions only (DMA TODO)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# SPI框架和BMI088 IMU驱动集成

## 概述
本PR引入通用SPI子系统并集成BMI088加速度计与陀螺仪驱动，采用SPI2中断回调完成传输，添加GPIO中断处理与应用层初始化，同时新增一个调试时的延迟断言工具以支持昂贵或条件化检查。

## 主要改动

### 1. 调试工具增强（core/src/utility/assert.hpp）
- 新增模板化的延迟断言函数 assert_debug_lazy：接受一个nothrow可调用的谓词，在Debug构建中通过 std::invoke 求值并断言结果，Release构建中为无操作，从而避免运行时开销。

### 2. SPI框架实现（firmware/src/spi/）
- 新增 ChipSelectPin 结构体表示基于GPIO的片选配置。
- 新增抽象接口 ISpiModule（用于设备驱动继承），包含纯虚回调 transmit_receive_completed_callback(size_t)。
- 新增具体管理类 Spi：
  - 提供 Lazy 初始化别名与静态 spi2 实例（HPM_SPI2_BASE，IRQn_SPI2，10 Mbps）。
  - 原子锁（std::atomic_flag）用于传输序列化（try_lock/unlock）。
  - FIFO 基础的同步 transmit_receive 路径（支持 ≤ kHardwareFifoSize），超出则留作 DMA TODO。
  - begin_transfer / finish_transfer 管理 CS 控制与传输状态。
  - 公共对齐的 tx_buffer / rx_buffer（L1 缓存行对齐）。
- SPI2 中断服务（firmware/src/spi/spi.cpp）：
  - 添加 spi2_isr，读取中断标志、在 end 标志时调用当前模块的 transmit_receive_completed_callback，并清除中断状态；无标志时快速返回（[[unlikely]]）。

### 3. BMI088 驱动（firmware/src/spi/bmi088/）
- accel.hpp（Accelerometer）：
  - 完整的BMI088加速度计类，支持量程与数据速率配置、软复位/WHO_AM_I 校验、数据就绪中断配置与回调（data_ready_callback），通过 SPI 发起读并在完成时解析数据，上链至 USB serializer。
  - 提供 prepare_tx_buffer_* 辅助和静态 inline Lazy 实例绑定 spi2 与指定 CS。
- gyro.hpp（Gyroscope）：
  - 完整的BMI088陀螺仪类，支持量程与带宽配置，初始化包含寄存器复位、Who Am I 验证、重试-读回确认模式，data_ready_callback 触发读取并在完成时序列化上链。
  - 提供静态 inline Lazy 实例绑定 spi2 与指定 CS。

### 4. GPIO 中断处理（firmware/src/gpio/）
- 新增头文件与实现：声明并实现 void init_bmi088_interrupts()。
- 为加速度计与陀螺仪分别配置 GPIO 引脚、中断触发（下降沿/active-low）、中断优先级与使能，并通过 SDK_DECLARE_EXT_ISR_M 绑定 ISR。
- ISR 回调在触发时调用对应 spi::bmi088 设备对象的 data_ready_callback。

### 5. 应用初始化（firmware/src/app.cpp）
- 在 App 构造流程中添加 BMI088 驱动与中断初始化（在 CAN 初始化之后、USB 初始化之前调用），确保传感器和中断在 USB 上链前就绪。

## 关键特性与设计要点
- 中断驱动的读取路径：数据就绪中断触发异步 SPI 读取，减少轮询开销。
- SPI 传输序列化：使用原子标志避免并发传输冲突；中断回调负责完成/解锁逻辑。
- USB 上链：传感器数据通过 Serializer 接口序列化并上传主机。
- 驱动配置稳健性：对关键寄存器写入采用重试与读回确认。
- 性能优化：TX/RX 缓冲区按 L1 缓存行对齐，便于将来 DMA 支持。

## 限制与待办
- 当前 SPI 仅支持 FIFO 大小（≤ kHardwareFifoSize）的事务，同步路径；对更大传输需补充 DMA 支持（标注为 TODO）。
- 增加了新的全局/静态设备实例与中断入口，代码审查时需注意初始化顺序和中断优先级对系统其他外设的影响。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->