### PR TITLE
feat(docs): Add AGENTS.md for project guidelines and development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# 仓库指南
+
+## 项目结构与模块组织
+- `core/`：共享协议、数据模型和工具代码（`core/include/librmcs`、`core/src`）。
+- `host/`：桌面端 SDK/库源码和公共头文件（`host/include/librmcs`、`host/src`），构建产物为 `librmcs-sdk`。
+- `firmware/rmcs_board/`：基于 HPM 的板卡固件。
+- `firmware/c_board/`：STM32 固件，分为 `app/` 和 `bootloader/` 两部分。
+- `firmware/*/bsp/`：厂商/子模块依赖；除非有意更新子模块，否则视为第三方代码。
+- `.scripts/`：与 CI 对齐的工具脚本（`clang-format-check`、`clang-tidy-check`、`generate_version`）。
+
+## 构建、测试与开发命令
+```bash
+cmake --preset linux-debug -S host
+cmake --build host/build
+
+cmake --preset debug -S firmware/rmcs_board
+cmake --build firmware/rmcs_board/build
+
+cmake --preset debug -S firmware/c_board
+cmake --build firmware/c_board/build --target c_board_app c_board_bootloader
+```
+
+```bash
+.scripts/clang-format-check --fix    # 应用格式修复
+.scripts/clang-tidy-check            # 静态分析（需在 CMake configure 之后运行）
+```
+
+`.scripts/clang-tidy-check --fix` 可触发 clang-tidy 自动修复，但部分修复可能不符合预期，需手动调整。
+例如: int var 会被修复为 int const var. 但项目中使用的 Google 风格要求使用 const int var。
+
+## 代码风格与命名规范
+- 语言：C11 + C++23，禁用 GNU 扩展。
+- 格式：4 空格缩进，100 列宽度限制，指针左对齐，启用 include 排序。
+- 命名：Google 风格，但函数命名为小写下划线。
+- 代码不允许包含任何非 ASCII 字符（Markdown 文档除外）。
+
+## 测试指南
+- 目前尚未启用 CTest/GTest 测试目标；当前 CI 质量门禁为：clang-format、clang-tidy 和 编译验证。
+- 每次修改后，应在本地运行 lint 工具，并至少构建一个相关的构建目标。
+
+## 提交指南
+- Git unstaged changes 是必要的 code review 渠道。Agent 严禁执行 git add。 
+- Commit Message 全英文，不允许包含任何非 ASCII 字符。
+- 遵循仓库的 Conventional Commit 风格；破坏性变更使用 `!` 标记。
+- 冒号后首字母需大写：`feat(scope): Capitalize the first letter of the title`。
+- 每次提交应聚焦于单个模块或关注点。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 概述
新增仓库指南文档 `AGENTS.md`，为开发者提供项目组织、构建流程、代码风格和提交规范的详细说明。

## 核心变更

**新增文件：`AGENTS.md`**
- 中文项目指南文档，包含以下主要内容：

**项目结构**
- 明确了 `core/`（共享协议和工具）、`host/`（桌面SDK）、`firmware/rmcs_board/`（HPM板卡固件）、`firmware/c_board/`（STM32固件）等模块的职责
- 说明了 `bsp/` 为第三方子模块依赖，`.scripts/` 包含 CI 对齐的工具脚本

**开发命令**
- 提供了 host、rmcs_board、c_board 的 CMake 构建预设命令
- 文档了代码检查工具使用方式（`clang-format-check --fix`、`clang-tidy-check`）
- 注明 clang-tidy 自动修复可能不完美，需手动调整

**代码规范**
- 语言标准：C11 + C++23，禁用 GNU 扩展
- 格式要求：4空格缩进、100列宽度限制、指针左对齐、启用include排序
- 命名规范：Google 风格但函数采用小写下划线
- 代码禁止非 ASCII 字符（Markdown 文档除外）

**质量与提交规范**
- CI 质量门禁：clang-format、clang-tidy 和编译验证
- Git 工作流：必须使用 unstaged changes 供审查，Agent 禁止执行 git add
- Commit Message：全英文、ASCII 字符限制、遵循 Conventional Commits 格式、破坏性变更使用 `!` 标记、冒号后首字母大写

**新增/修改文件**
- `AGENTS.md`（+46 行）
- `CLAUDE.md` 更新（+1 行，添加了对 AGENTS.md 的记录）

## 代码审查难度
低（纯文档新增）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->