### PR TITLE
feat(sensor): Add timestamp difference handling for IMU data processing

### DIFF
--- a/core/include/librmcs/data/datas.hpp
+++ b/core/include/librmcs/data/datas.hpp
@@ -71,12 +71,14 @@ struct AccelerometerDataView {
     int16_t x;
     int16_t y;
     int16_t z;
+    uint16_t timestamp_diff_quarter_us;
 };
 
 struct GyroscopeDataView {
     int16_t x;
     int16_t y;
     int16_t z;
+    uint16_t timestamp_diff_quarter_us;
 };
 
 class DataCallback {

--- a/core/src/protocol/deserializer.cpp
+++ b/core/src/protocol/deserializer.cpp
@@ -267,6 +267,8 @@ coroutine::LifoTask<bool> Deserializer::process_imu_field(FieldId) {
         data_view.x = payload.get<ImuAccelerometerPayload::X>();
         data_view.y = payload.get<ImuAccelerometerPayload::Y>();
         data_view.z = payload.get<ImuAccelerometerPayload::Z>();
+        data_view.timestamp_diff_quarter_us =
+            payload.get<ImuAccelerometerPayload::TimestampDiffQuarterUs>();
         consume_peeked();
         callback_.accelerometer_deserialized_callback(data_view);
         break;
@@ -280,6 +282,8 @@ coroutine::LifoTask<bool> Deserializer::process_imu_field(FieldId) {
         data_view.x = payload.get<ImuGyroscopePayload::X>();
         data_view.y = payload.get<ImuGyroscopePayload::Y>();
         data_view.z = payload.get<ImuGyroscopePayload::Z>();
+        data_view.timestamp_diff_quarter_us =
+            payload.get<ImuGyroscopePayload::TimestampDiffQuarterUs>();
         consume_peeked();
         callback_.gyroscope_deserialized_callback(data_view);
         break;

--- a/core/src/protocol/protocol.hpp
+++ b/core/src/protocol/protocol.hpp
@@ -118,16 +118,18 @@ struct ImuHeader : utility::Bitfield<1> {
     using PayloadType = utility::BitfieldMember<4, 4, PayloadEnum>;
 };
 
-struct ImuAccelerometerPayload : utility::Bitfield<6> {
+struct ImuAccelerometerPayload : utility::Bitfield<8> {
     using X = utility::BitfieldMember<0, 16, int16_t>;
     using Y = utility::BitfieldMember<16, 16, int16_t>;
     using Z = utility::BitfieldMember<32, 16, int16_t>;
+    using TimestampDiffQuarterUs = utility::BitfieldMember<48, 16, uint16_t>;
 };
 
-struct ImuGyroscopePayload : utility::Bitfield<6> {
+struct ImuGyroscopePayload : utility::Bitfield<8> {
     using X = utility::BitfieldMember<0, 16, int16_t>;
     using Y = utility::BitfieldMember<16, 16, int16_t>;
     using Z = utility::BitfieldMember<32, 16, int16_t>;
+    using TimestampDiffQuarterUs = utility::BitfieldMember<48, 16, uint16_t>;
 };
 
 } // namespace librmcs::core::protocol

--- a/core/src/protocol/serializer.hpp
+++ b/core/src/protocol/serializer.hpp
@@ -304,6 +304,8 @@ public:
         payload.set<ImuAccelerometerPayload::X>(view.x);
         payload.set<ImuAccelerometerPayload::Y>(view.y);
         payload.set<ImuAccelerometerPayload::Z>(view.z);
+        payload.set<ImuAccelerometerPayload::TimestampDiffQuarterUs>(
+            view.timestamp_diff_quarter_us);
 
         utility::assert_debug(cursor == dst.data() + dst.size());
         return SerializeResult::kSuccess;
@@ -329,6 +331,7 @@ public:
         payload.set<ImuGyroscopePayload::X>(view.x);
         payload.set<ImuGyroscopePayload::Y>(view.y);
         payload.set<ImuGyroscopePayload::Z>(view.z);
+        payload.set<ImuGyroscopePayload::TimestampDiffQuarterUs>(view.timestamp_diff_quarter_us);
 
         utility::assert_debug(cursor == dst.data() + dst.size());
         return SerializeResult::kSuccess;

--- a/firmware/c_board/app/src/gpio/gpio.cpp
+++ b/firmware/c_board/app/src/gpio/gpio.cpp
@@ -7,14 +7,19 @@
 
 #include "firmware/c_board/app/src/spi/bmi088/accel.hpp"
 #include "firmware/c_board/app/src/spi/bmi088/gyro.hpp"
+#include "firmware/c_board/app/src/timer/timer.hpp"
 
 namespace librmcs::firmware::gpio {
 
 extern "C" void HAL_GPIO_EXTI_Callback(uint16_t gpio_pin) {
     if (gpio_pin == INT1_ACC_Pin) {
-        spi::bmi088::accelerometer->data_ready_callback();
+        const uint32_t capture_timestamp_quarter_us =
+            timer::timer->timepoint().time_since_epoch().count();
+        spi::bmi088::accelerometer->data_ready_callback(capture_timestamp_quarter_us);
     } else if (gpio_pin == INT1_GYRO_Pin) {
-        spi::bmi088::gyroscope->data_ready_callback();
+        const uint32_t capture_timestamp_quarter_us =
+            timer::timer->timepoint().time_since_epoch().count();
+        spi::bmi088::gyroscope->data_ready_callback(capture_timestamp_quarter_us);
     } else {
         gpio::gpio->handle_input_edge_interrupt(gpio_pin);
     }

--- a/firmware/c_board/app/src/spi/bmi088/accel.hpp
+++ b/firmware/c_board/app/src/spi/bmi088/accel.hpp
@@ -3,6 +3,7 @@
 #include <chrono> // IWYU pragma: keep (https://github.com/llvm/llvm-project/issues/68213)
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 
 #include <main.h>
 
@@ -52,6 +53,8 @@ class Accelerometer final
     , private Bmi088Base<AccelerometerTraits> {
 public:
     using Lazy = utility::Lazy<Accelerometer, Spi::Lazy*>;
+
+    static constexpr uint16_t kFirstFrameTimestampDiffQuarterUs = 1'000'000 / 1600 * 4;
 
     enum class Range : uint8_t { k3G = 0x00, k6G = 0x01, k12G = 0x02, k24G = 0x03 };
     enum class DataRate : uint8_t {
@@ -105,22 +108,60 @@ public:
         spi_.unlock();
     }
 
-    void data_ready_callback() { read_async(RegisterAddress::kAccXLsb, 6); }
+    void data_ready_callback(uint32_t capture_timestamp_quarter_us) {
+        if (read_async(RegisterAddress::kAccXLsb, 6)) {
+            pending_capture_timestamp_quarter_us_ = capture_timestamp_quarter_us;
+            has_pending_capture_timestamp_ = true;
+        }
+    }
 
 private:
     void transmit_receive_async_callback(size_t size) override {
-        if (size) [[likely]] {
+        core::utility::assert_debug(!size || has_pending_capture_timestamp_);
+        if (size && has_pending_capture_timestamp_) [[likely]] {
             auto& data = parse_rx_data(spi_.rx_buffer, size);
-            handle_uplink(usb::vendor->serializer(), data);
+            handle_uplink(usb::vendor->serializer(), data, pending_capture_timestamp_quarter_us_);
         }
+        has_pending_capture_timestamp_ = false;
         spi_.unlock();
     }
 
-    static void handle_uplink(core::protocol::Serializer& serializer, Data& data) {
+    void handle_uplink(
+        core::protocol::Serializer& serializer, Data& data, uint32_t capture_timestamp_quarter_us) {
+        const uint16_t timestamp_diff_quarter_us =
+            calculate_timestamp_diff_quarter_us(capture_timestamp_quarter_us);
+        const auto result = serializer.write_imu_accelerometer({
+            .x = data.x,
+            .y = data.y,
+            .z = data.z,
+            .timestamp_diff_quarter_us = timestamp_diff_quarter_us,
+        });
         core::utility::assert_debug(
-            serializer.write_imu_accelerometer({.x = data.x, .y = data.y, .z = data.z})
-            != core::protocol::Serializer::SerializeResult::kInvalidArgument);
+            result != core::protocol::Serializer::SerializeResult::kInvalidArgument);
+        if (result == core::protocol::Serializer::SerializeResult::kSuccess) {
+            last_success_capture_timestamp_quarter_us_ = capture_timestamp_quarter_us;
+            has_last_success_capture_timestamp_ = true;
+        }
     }
+
+    uint16_t calculate_timestamp_diff_quarter_us(uint32_t capture_timestamp_quarter_us) const {
+        if (!has_last_success_capture_timestamp_)
+            return kFirstFrameTimestampDiffQuarterUs;
+
+        return saturate_timestamp_diff_quarter_us(
+            capture_timestamp_quarter_us - last_success_capture_timestamp_quarter_us_);
+    }
+
+    static uint16_t saturate_timestamp_diff_quarter_us(uint32_t timestamp_diff_quarter_us) {
+        if (timestamp_diff_quarter_us > std::numeric_limits<uint16_t>::max())
+            return std::numeric_limits<uint16_t>::max();
+        return static_cast<uint16_t>(timestamp_diff_quarter_us);
+    }
+
+    uint32_t pending_capture_timestamp_quarter_us_ = 0;
+    uint32_t last_success_capture_timestamp_quarter_us_ = 0;
+    bool has_pending_capture_timestamp_ = false;
+    bool has_last_success_capture_timestamp_ = false;
 };
 
 inline constinit Accelerometer::Lazy accelerometer(&spi1);

--- a/firmware/c_board/app/src/spi/bmi088/gyro.hpp
+++ b/firmware/c_board/app/src/spi/bmi088/gyro.hpp
@@ -3,6 +3,7 @@
 #include <chrono> // IWYU pragma: keep (https://github.com/llvm/llvm-project/issues/68213)
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 
 #include <main.h>
 
@@ -44,6 +45,8 @@ class Gyroscope final
     , private Bmi088Base<GyroscopeTraits> {
 public:
     using Lazy = utility::Lazy<Gyroscope, Spi::Lazy*>;
+
+    static constexpr uint16_t kFirstFrameTimestampDiffQuarterUs = 1'000'000 / 2000 * 4;
 
     enum class Range : uint8_t {
         k2000 = 0x00,
@@ -100,22 +103,60 @@ public:
         spi_.unlock();
     }
 
-    void data_ready_callback() { read_async(RegisterAddress::kRateXLsb, 6); }
+    void data_ready_callback(uint32_t capture_timestamp_quarter_us) {
+        if (read_async(RegisterAddress::kRateXLsb, 6)) {
+            pending_capture_timestamp_quarter_us_ = capture_timestamp_quarter_us;
+            has_pending_capture_timestamp_ = true;
+        }
+    }
 
 private:
     void transmit_receive_async_callback(size_t size) override {
-        if (size) [[likely]] {
+        core::utility::assert_debug(!size || has_pending_capture_timestamp_);
+        if (size && has_pending_capture_timestamp_) [[likely]] {
             auto& data = parse_rx_data(spi_.rx_buffer, size);
-            handle_uplink(usb::vendor->serializer(), data);
+            handle_uplink(usb::vendor->serializer(), data, pending_capture_timestamp_quarter_us_);
         }
+        has_pending_capture_timestamp_ = false;
         spi_.unlock();
     }
 
-    static void handle_uplink(core::protocol::Serializer& serializer, Data& data) {
+    void handle_uplink(
+        core::protocol::Serializer& serializer, Data& data, uint32_t capture_timestamp_quarter_us) {
+        const uint16_t timestamp_diff_quarter_us =
+            calculate_timestamp_diff_quarter_us(capture_timestamp_quarter_us);
+        const auto result = serializer.write_imu_gyroscope({
+            .x = data.x,
+            .y = data.y,
+            .z = data.z,
+            .timestamp_diff_quarter_us = timestamp_diff_quarter_us,
+        });
         core::utility::assert_debug(
-            serializer.write_imu_gyroscope({.x = data.x, .y = data.y, .z = data.z})
-            != core::protocol::Serializer::SerializeResult::kInvalidArgument);
+            result != core::protocol::Serializer::SerializeResult::kInvalidArgument);
+        if (result == core::protocol::Serializer::SerializeResult::kSuccess) {
+            last_success_capture_timestamp_quarter_us_ = capture_timestamp_quarter_us;
+            has_last_success_capture_timestamp_ = true;
+        }
     }
+
+    uint16_t calculate_timestamp_diff_quarter_us(uint32_t capture_timestamp_quarter_us) const {
+        if (!has_last_success_capture_timestamp_)
+            return kFirstFrameTimestampDiffQuarterUs;
+
+        return saturate_timestamp_diff_quarter_us(
+            capture_timestamp_quarter_us - last_success_capture_timestamp_quarter_us_);
+    }
+
+    static uint16_t saturate_timestamp_diff_quarter_us(uint32_t timestamp_diff_quarter_us) {
+        if (timestamp_diff_quarter_us > std::numeric_limits<uint16_t>::max())
+            return std::numeric_limits<uint16_t>::max();
+        return static_cast<uint16_t>(timestamp_diff_quarter_us);
+    }
+
+    uint32_t pending_capture_timestamp_quarter_us_ = 0;
+    uint32_t last_success_capture_timestamp_quarter_us_ = 0;
+    bool has_pending_capture_timestamp_ = false;
+    bool has_last_success_capture_timestamp_ = false;
 };
 
 inline constinit Gyroscope::Lazy gyroscope(&spi1);

--- a/firmware/rmcs_board/src/gpio/gpio.cpp
+++ b/firmware/rmcs_board/src/gpio/gpio.cpp
@@ -9,6 +9,7 @@
 #include <hpm_gpiom_soc_drv.h>
 #include <hpm_ioc_regs.h>
 #include <hpm_iomux.h>
+#include <hpm_mchtmr_drv.h>
 #include <hpm_pmic_iomux.h>
 #include <hpm_soc.h>
 #include <hpm_soc_irq.h>
@@ -58,14 +59,18 @@ void init_bmi088_interrupts() {
 SDK_DECLARE_EXT_ISR_M(IRQn_GPIO0_B, gpio_bmi088_int_gyro_isr)
 void gpio_bmi088_int_gyro_isr() {
     if (gpio_check_clear_interrupt_flag(HPM_GPIO0, GPIO_DI_GPIOB, kBmi088IntGyroPin)) {
-        spi::bmi088::gyroscope->data_ready_callback();
+        const uint32_t capture_timestamp_quarter_us =
+            static_cast<uint32_t>(mchtmr_get_count(HPM_MCHTMR) / 6U);
+        spi::bmi088::gyroscope->data_ready_callback(capture_timestamp_quarter_us);
     }
 }
 
 SDK_DECLARE_EXT_ISR_M(IRQn_GPIO0_Y, gpio_bmi088_int_accel_isr)
 void gpio_bmi088_int_accel_isr() {
     if (gpio_check_clear_interrupt_flag(HPM_GPIO0, GPIO_DI_GPIOY, kBmi088IntAccelPin)) {
-        spi::bmi088::accelerometer->data_ready_callback();
+        const uint32_t capture_timestamp_quarter_us =
+            static_cast<uint32_t>(mchtmr_get_count(HPM_MCHTMR) / 6U);
+        spi::bmi088::accelerometer->data_ready_callback(capture_timestamp_quarter_us);
     }
 }
 

--- a/firmware/rmcs_board/src/spi/bmi088/accel.hpp
+++ b/firmware/rmcs_board/src/spi/bmi088/accel.hpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 
 #include <board.h>
 #include <hpm_gpio_regs.h>
@@ -52,6 +53,8 @@ class Accelerometer final
     , private Bmi088Base<AccelerometerTraits> {
 public:
     using Lazy = utility::Lazy<Accelerometer, Spi::Lazy*, ChipSelectPin>;
+
+    static constexpr uint16_t kFirstFrameTimestampDiffQuarterUs = 1'000'000 / 1600 * 4;
 
     enum class Range : uint8_t { k3G = 0x00, k6G = 0x01, k12G = 0x02, k24G = 0x03 };
     enum class DataRate : uint8_t {
@@ -104,22 +107,60 @@ public:
         spi_.unlock();
     }
 
-    void data_ready_callback() { read_async(RegisterAddress::kAccXLsb, 6); }
+    void data_ready_callback(uint32_t capture_timestamp_quarter_us) {
+        if (read_async(RegisterAddress::kAccXLsb, 6)) {
+            pending_capture_timestamp_quarter_us_ = capture_timestamp_quarter_us;
+            has_pending_capture_timestamp_ = true;
+        }
+    }
 
 private:
     void transmit_receive_async_callback(std::size_t size) override {
-        if (size) [[likely]] {
+        core::utility::assert_debug(!size || has_pending_capture_timestamp_);
+        if (size && has_pending_capture_timestamp_) [[likely]] {
             auto& data = parse_rx_data(spi_.rx_buffer, size);
-            handle_uplink(usb::vendor->serializer(), data);
+            handle_uplink(usb::vendor->serializer(), data, pending_capture_timestamp_quarter_us_);
         }
+        has_pending_capture_timestamp_ = false;
         spi_.unlock();
     }
 
-    static void handle_uplink(core::protocol::Serializer& serializer, Data& data) {
+    void handle_uplink(
+        core::protocol::Serializer& serializer, Data& data, uint32_t capture_timestamp_quarter_us) {
+        const uint16_t timestamp_diff_quarter_us =
+            calculate_timestamp_diff_quarter_us(capture_timestamp_quarter_us);
+        const auto result = serializer.write_imu_accelerometer({
+            .x = data.x,
+            .y = data.y,
+            .z = data.z,
+            .timestamp_diff_quarter_us = timestamp_diff_quarter_us,
+        });
         core::utility::assert_debug(
-            serializer.write_imu_accelerometer({.x = data.x, .y = data.y, .z = data.z})
-            != core::protocol::Serializer::SerializeResult::kInvalidArgument);
+            result != core::protocol::Serializer::SerializeResult::kInvalidArgument);
+        if (result == core::protocol::Serializer::SerializeResult::kSuccess) {
+            last_success_capture_timestamp_quarter_us_ = capture_timestamp_quarter_us;
+            has_last_success_capture_timestamp_ = true;
+        }
     }
+
+    uint16_t calculate_timestamp_diff_quarter_us(uint32_t capture_timestamp_quarter_us) const {
+        if (!has_last_success_capture_timestamp_)
+            return kFirstFrameTimestampDiffQuarterUs;
+
+        return saturate_timestamp_diff_quarter_us(
+            capture_timestamp_quarter_us - last_success_capture_timestamp_quarter_us_);
+    }
+
+    static uint16_t saturate_timestamp_diff_quarter_us(uint32_t timestamp_diff_quarter_us) {
+        if (timestamp_diff_quarter_us > std::numeric_limits<uint16_t>::max())
+            return std::numeric_limits<uint16_t>::max();
+        return static_cast<uint16_t>(timestamp_diff_quarter_us);
+    }
+
+    uint32_t pending_capture_timestamp_quarter_us_ = 0;
+    uint32_t last_success_capture_timestamp_quarter_us_ = 0;
+    bool has_pending_capture_timestamp_ = false;
+    bool has_last_success_capture_timestamp_ = false;
 };
 
 inline Accelerometer::Lazy accelerometer(

--- a/firmware/rmcs_board/src/spi/bmi088/gyro.hpp
+++ b/firmware/rmcs_board/src/spi/bmi088/gyro.hpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 
 #include <board.h>
 #include <hpm_gpio_regs.h>
@@ -44,6 +45,8 @@ class Gyroscope final
     , private Bmi088Base<GyroscopeTraits> {
 public:
     using Lazy = utility::Lazy<Gyroscope, Spi::Lazy*, ChipSelectPin>;
+
+    static constexpr uint16_t kFirstFrameTimestampDiffQuarterUs = 1'000'000 / 2000 * 4;
 
     enum class DataRange : uint8_t {
         k2000 = 0x00,
@@ -98,22 +101,60 @@ public:
         spi_.unlock();
     }
 
-    void data_ready_callback() { read_async(RegisterAddress::kRateXLsb, 6); }
+    void data_ready_callback(uint32_t capture_timestamp_quarter_us) {
+        if (read_async(RegisterAddress::kRateXLsb, 6)) {
+            pending_capture_timestamp_quarter_us_ = capture_timestamp_quarter_us;
+            has_pending_capture_timestamp_ = true;
+        }
+    }
 
 private:
     void transmit_receive_async_callback(std::size_t size) override {
-        if (size) [[likely]] {
+        core::utility::assert_debug(!size || has_pending_capture_timestamp_);
+        if (size && has_pending_capture_timestamp_) [[likely]] {
             auto& data = parse_rx_data(spi_.rx_buffer, size);
-            handle_uplink(usb::vendor->serializer(), data);
+            handle_uplink(usb::vendor->serializer(), data, pending_capture_timestamp_quarter_us_);
         }
+        has_pending_capture_timestamp_ = false;
         spi_.unlock();
     }
 
-    static void handle_uplink(core::protocol::Serializer& serializer, Data& data) {
+    void handle_uplink(
+        core::protocol::Serializer& serializer, Data& data, uint32_t capture_timestamp_quarter_us) {
+        const uint16_t timestamp_diff_quarter_us =
+            calculate_timestamp_diff_quarter_us(capture_timestamp_quarter_us);
+        const auto result = serializer.write_imu_gyroscope({
+            .x = data.x,
+            .y = data.y,
+            .z = data.z,
+            .timestamp_diff_quarter_us = timestamp_diff_quarter_us,
+        });
         core::utility::assert_debug(
-            serializer.write_imu_gyroscope({.x = data.x, .y = data.y, .z = data.z})
-            != core::protocol::Serializer::SerializeResult::kInvalidArgument);
+            result != core::protocol::Serializer::SerializeResult::kInvalidArgument);
+        if (result == core::protocol::Serializer::SerializeResult::kSuccess) {
+            last_success_capture_timestamp_quarter_us_ = capture_timestamp_quarter_us;
+            has_last_success_capture_timestamp_ = true;
+        }
     }
+
+    uint16_t calculate_timestamp_diff_quarter_us(uint32_t capture_timestamp_quarter_us) const {
+        if (!has_last_success_capture_timestamp_)
+            return kFirstFrameTimestampDiffQuarterUs;
+
+        return saturate_timestamp_diff_quarter_us(
+            capture_timestamp_quarter_us - last_success_capture_timestamp_quarter_us_);
+    }
+
+    static uint16_t saturate_timestamp_diff_quarter_us(uint32_t timestamp_diff_quarter_us) {
+        if (timestamp_diff_quarter_us > std::numeric_limits<uint16_t>::max())
+            return std::numeric_limits<uint16_t>::max();
+        return static_cast<uint16_t>(timestamp_diff_quarter_us);
+    }
+
+    uint32_t pending_capture_timestamp_quarter_us_ = 0;
+    uint32_t last_success_capture_timestamp_quarter_us_ = 0;
+    bool has_pending_capture_timestamp_ = false;
+    bool has_last_success_capture_timestamp_ = false;
 };
 
 inline Gyroscope::Lazy gyroscope(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Pull Request 摘要

## 概述
该PR为IMU（惯性测量单元）数据处理添加了时间戳差值处理功能，使加速度计和陀螺仪能够报告相邻数据帧之间的时间差值（以四分之一微秒为单位），从而提供更精确的传感器数据时序信息。

## 主要改动

### 1. 数据结构扩展
- `AccelerometerDataView` 和 `GyroscopeDataView` 各新增 `uint16_t timestamp_diff_quarter_us` 字段，用于存储帧间时间差值

### 2. 协议层更新
- `ImuAccelerometerPayload` 和 `ImuGyroscopePayload` 的Bitfield大小从6扩展至8，在比特偏移48处新增 `TimestampDiffQuarterUs` 字段（16位无符号整数）
- 保持现有的X/Y/Z轴字段不变

### 3. 序列化/反序列化
- 反序列化器在处理加速度计和陀螺仪数据时读取新的时间戳差值字段
- 序列化器在写入IMU数据时，将视图中的 `timestamp_diff_quarter_us` 写入有效负载

### 4. GPIO中断时间戳捕获
- **c_board**：在 `HAL_GPIO_EXTI_Callback` 中通过 `timer::timer->timepoint().time_since_epoch().count()` 捕获中断时间戳
- **rmcs_board**：通过 `mchtmr_get_count(HPM_MCHTMR) / 6U` 获取中断时间戳

### 5. 传感器驱动更新（加速度计和陀螺仪）
- `data_ready_callback()` 签名改为接收 `uint32_t capture_timestamp_quarter_us` 参数
- 新增内部状态追踪：
  - `pending_capture_timestamp_quarter_us_`：待处理的捕获时间戳
  - `last_success_capture_timestamp_quarter_us_`：上一次成功序列化的时间戳
  - 对应的标志位
- 新增常量 `kFirstFrameTimestampDiffQuarterUs`，用于首帧时间戳差值
- 时间戳差值计算逻辑：
  - 首帧使用固定常量值
  - 后续帧计算与上次成功帧的时间差
  - 差值溢出时饱和至 `uint16_t` 最大值
- "最后成功"时间戳仅在序列化成功时更新

## 变更规模
- 总计约12个文件改动，代码行数增加约±100行
- 主要代码复杂度增加在传感器驱动层（加速度计和陀螺仪），评估为高复杂度

<!-- end of auto-generated comment: release notes by coderabbit.ai -->