### PR TITLE
build(docker): Pin LLVM toolchain to version 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,19 +92,19 @@ RUN VERSION=15.2.rel1 \
 ENV GNUARM_TOOLCHAIN_PATH=/opt/arm-none-eabi
 ENV PATH="${GNUARM_TOOLCHAIN_PATH}/bin:${PATH}"
 
-# Install latest LLVM tools
-RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
-    && echo "deb https://apt.llvm.org/noble/ llvm-toolchain-noble main" > /etc/apt/sources.list.d/llvm.list \
+# Install LLVM tools
+RUN LLVM_VERSION=22 \
+    && wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
+    && echo "deb https://apt.llvm.org/noble/ llvm-toolchain-noble-${LLVM_VERSION} main" > /etc/apt/sources.list.d/llvm.list \
     && apt-get update \
-    && version=$(apt-cache search clangd- | grep clangd- | awk -F' ' '{print $1}' | sort -V | tail -1 | cut -d- -f2) \
     && apt-get install -y --no-install-recommends \
-    clangd-$version clang-tidy-$version clang-format-$version \
+    clangd-${LLVM_VERSION} clang-tidy-${LLVM_VERSION} clang-format-${LLVM_VERSION} \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* \
-    && update-alternatives --install /usr/bin/clangd clangd /usr/bin/clangd-$version 50 \
-    && update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-$version 50 \
-    && update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-$version 50
+    && update-alternatives --install /usr/bin/clangd clangd /usr/bin/clangd-${LLVM_VERSION} 50 \
+    && update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-${LLVM_VERSION} 50 \
+    && update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-${LLVM_VERSION} 50
 
 FROM ci AS develop
 

--- a/firmware/c_board/app/src/timer/timer.hpp
+++ b/firmware/c_board/app/src/timer/timer.hpp
@@ -45,9 +45,7 @@ public:
             HAL_TIM_Base_Start(kTimerHigh) == HAL_OK && HAL_TIM_Base_Start(kTimerLow) == HAL_OK);
     }
 
-    TimePoint timepoint() const {
-        return TimePoint{Duration{timer_counter_low_}};
-    }
+    TimePoint timepoint() const { return TimePoint{Duration{timer_counter_low_}}; }
 
     TimePoint48 timepoint48() const {
         uint32_t hi1, hi2, lo;


### PR DESCRIPTION
Replace dynamic version detection with fixed LLVM_VERSION variable to ensure reproducible builds. The version is now pinned to LLVM 22 (stable branch) while accepting patch updates within 22.x series.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 摘要

本 PR 将 Dockerfile 中 LLVM 工具链的动态版本检测替换为固定主版本，以确保可重复构建；同时包含一个无行为变更的格式化调整。

### 主要变更

**Dockerfile — LLVM 工具链安装**
- 引入构建变量 `LLVM_VERSION=22`，将 LLVM 主版本固定为 22（允许 22.x 补丁更新）。
- 将 APT 源改为 `llvm-toolchain-noble-${LLVM_VERSION}`，移除原先基于 `apt-cache` 的动态版本发现逻辑。
- 明确安装版本化包：`clangd-${LLVM_VERSION}`、`clang-tidy-${LLVM_VERSION}`、`clang-format-${LLVM_VERSION}`（不再在构建时解析最新具体包版本）。
- 使用 `update-alternatives` 将 `/usr/bin/clangd`、`/usr/bin/clang-tidy`、`/usr/bin/clang-format` 指向对应的 `${LLVM_VERSION}` 后缀二进制，并设置优先级。

**firmware/c_board/app/src/timer/timer.hpp**
- 将 `Timer::timepoint() const` 的实现从多行合并为单行表达，行为和接口不变（仅格式化/样式调整）。

### 影响与收益
- 可重复构建：通过固定主版本避免不同时间或环境下因工具链自动升级导致的构建差异。
- 兼顾安全性与灵活性：锁定主版本（22），允许补丁级别（22.x）更新。
- 代码可维护性提升：工具链版本在构建脚本中显式可见，便于审计与追踪。
- 代码接口未更改：不影响导出或公共实体；timer.hpp 仅为样式变更。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->