### PR TITLE
feat(gpio)!: Add GPIO support for rmcs_board

### DIFF
--- a/core/include/librmcs/data/datas.hpp
+++ b/core/include/librmcs/data/datas.hpp
@@ -4,6 +4,8 @@
 #include <cstdint>
 #include <span>
 
+#include <librmcs/spec/gpio.hpp>
+
 namespace librmcs::data {
 
 enum class DataId : uint8_t {
@@ -43,12 +45,10 @@ struct UartDataView {
 };
 
 struct GpioDigitalDataView {
-    uint8_t channel;
     bool high;
 };
 
 struct GpioAnalogDataView {
-    uint8_t channel;
     uint16_t value;
 };
 
@@ -59,12 +59,20 @@ enum class GpioPull : uint8_t {
 };
 
 struct GpioReadConfigView {
-    uint8_t channel;
     uint16_t period_ms = 0;
     bool asap = false;
     bool rising_edge = false;
     bool falling_edge = false;
     GpioPull pull = GpioPull::kNone;
+
+    [[nodiscard]] constexpr bool supported(const spec::GpioDescriptor& gpio) const noexcept {
+        return (!asap || gpio.supports(spec::GpioCapability::kDigitalReadOnce))
+            && (!period_ms || gpio.supports(spec::GpioCapability::kDigitalReadPeriodic))
+            && ((!rising_edge && !falling_edge)
+                || gpio.supports(spec::GpioCapability::kDigitalReadInterrupt))
+            && (pull != GpioPull::kUp || gpio.supports(spec::GpioCapability::kPullUp))
+            && (pull != GpioPull::kDown || gpio.supports(spec::GpioCapability::kPullDown));
+    }
 };
 
 struct AccelerometerDataView {
@@ -93,9 +101,11 @@ public:
 
     virtual bool uart_receive_callback(DataId id, const UartDataView& data) = 0;
 
-    virtual void gpio_digital_read_result_callback(const GpioDigitalDataView& data) = 0;
+    virtual void gpio_digital_read_result_callback(
+        uint8_t channel_index, const GpioDigitalDataView& data) = 0;
 
-    virtual void gpio_analog_read_result_callback(const GpioAnalogDataView& data) = 0;
+    virtual void
+        gpio_analog_read_result_callback(uint8_t channel_index, const GpioAnalogDataView& data) = 0;
 
     virtual void accelerometer_receive_callback(const AccelerometerDataView& data) = 0;
 

--- a/core/include/librmcs/spec/c_board/gpio.hpp
+++ b/core/include/librmcs/spec/c_board/gpio.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+
+#include <librmcs/spec/gpio.hpp>
+
+namespace librmcs::spec::c_board {
+
+namespace internal {
+class GpioDescriptors;
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
+class GpioDescriptor : public spec::GpioDescriptor {
+    friend internal::GpioDescriptors;
+    constexpr GpioDescriptor(uint8_t channel_index, GpioCapability capability_mask)
+        : spec::GpioDescriptor(channel_index, capability_mask) {}
+
+public:
+    GpioDescriptor(const GpioDescriptor&) = delete;
+    GpioDescriptor& operator=(const GpioDescriptor&) = delete;
+    GpioDescriptor(GpioDescriptor&&) = delete;
+    GpioDescriptor& operator=(GpioDescriptor&&) = delete;
+
+    [[nodiscard]] constexpr bool operator==(const GpioDescriptor& other) const noexcept {
+        return channel_index == other.channel_index;
+    }
+};
+
+namespace internal {
+class GpioDescriptors {
+    static constexpr GpioDescriptor kArray[]{
+        {0,                                          kAllGpioCapabilities},
+        {1,                                          kAllGpioCapabilities},
+        {2,                                          kAllGpioCapabilities},
+        {3,                                          kAllGpioCapabilities},
+        {4,                                          kAllGpioCapabilities},
+        {5, kAllGpioCapabilities & ~GpioCapability::kDigitalReadInterrupt},
+        {6,                                          kAllGpioCapabilities}
+    };
+    static_assert(channel_indices_match_indices(kArray));
+
+public:
+    constexpr GpioDescriptors() = default;
+
+    static constexpr std::size_t size() noexcept { return std::size(kArray); }
+
+    static constexpr const GpioDescriptor& operator[](std::size_t channel_index) noexcept {
+        return kArray[channel_index];
+    }
+
+    static constexpr const GpioDescriptor* begin() noexcept { return std::begin(kArray); }
+
+    static constexpr const GpioDescriptor* end() noexcept { return std::end(kArray); }
+
+    static constexpr const GpioDescriptor& kPwm1 = kArray[0];
+    static constexpr const GpioDescriptor& kPwm2 = kArray[1];
+    static constexpr const GpioDescriptor& kPwm3 = kArray[2];
+    static constexpr const GpioDescriptor& kPwm4 = kArray[3];
+    static constexpr const GpioDescriptor& kPwm5 = kArray[4];
+    static constexpr const GpioDescriptor& kPwm6 = kArray[5];
+    static constexpr const GpioDescriptor& kPwm7 = kArray[6];
+};
+} // namespace internal
+
+inline constexpr internal::GpioDescriptors kGpioDescriptors{};
+
+} // namespace librmcs::spec::c_board

--- a/core/include/librmcs/spec/gpio.hpp
+++ b/core/include/librmcs/spec/gpio.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace librmcs::spec {
+
+enum class GpioCapability : std::uint8_t {
+    kNone = 0,
+    kDigitalWrite = 1U << 0,
+    kAnalogWrite = 1U << 1,
+    kDigitalReadOnce = 1U << 2,
+    kDigitalReadPeriodic = 1U << 3,
+    kDigitalReadInterrupt = 1U << 4,
+    kPullUp = 1U << 5,
+    kPullDown = 1U << 6,
+};
+
+constexpr GpioCapability operator|(GpioCapability a, GpioCapability b) noexcept {
+    return static_cast<GpioCapability>(static_cast<std::uint8_t>(a) | static_cast<std::uint8_t>(b));
+}
+
+constexpr GpioCapability operator&(GpioCapability a, GpioCapability b) noexcept {
+    return static_cast<GpioCapability>(static_cast<std::uint8_t>(a) & static_cast<std::uint8_t>(b));
+}
+
+constexpr GpioCapability operator~(GpioCapability a) noexcept {
+    return static_cast<GpioCapability>(~static_cast<std::uint8_t>(a));
+}
+
+inline constexpr GpioCapability kAllGpioCapabilities =
+    GpioCapability::kDigitalWrite | GpioCapability::kAnalogWrite | GpioCapability::kDigitalReadOnce
+    | GpioCapability::kDigitalReadPeriodic | GpioCapability::kDigitalReadInterrupt
+    | GpioCapability::kPullUp | GpioCapability::kPullDown;
+
+struct GpioDescriptor {
+    std::uint8_t channel_index;
+    GpioCapability capability_mask = GpioCapability::kNone;
+
+    [[nodiscard]] constexpr bool supports(GpioCapability capability) const noexcept {
+        return (capability_mask & capability) == capability;
+    }
+};
+
+template <typename Descriptor, std::size_t n>
+[[nodiscard]] consteval bool
+    channel_indices_match_indices(const Descriptor (&descriptors)[n]) noexcept {
+    for (std::size_t index = 0; index < n; ++index) {
+        if (descriptors[index].channel_index != index)
+            return false;
+    }
+    return true;
+}
+
+} // namespace librmcs::spec

--- a/core/include/librmcs/spec/gpio.hpp
+++ b/core/include/librmcs/spec/gpio.hpp
@@ -28,10 +28,13 @@ constexpr GpioCapability operator~(GpioCapability a) noexcept {
     return static_cast<GpioCapability>(~static_cast<std::uint8_t>(a));
 }
 
-inline constexpr GpioCapability kAllGpioCapabilities =
-    GpioCapability::kDigitalWrite | GpioCapability::kAnalogWrite | GpioCapability::kDigitalReadOnce
+inline constexpr GpioCapability kDigitalCapabilities =
+    GpioCapability::kDigitalWrite | GpioCapability::kDigitalReadOnce
     | GpioCapability::kDigitalReadPeriodic | GpioCapability::kDigitalReadInterrupt
     | GpioCapability::kPullUp | GpioCapability::kPullDown;
+
+inline constexpr GpioCapability kPwmCapabilities =
+    kDigitalCapabilities | GpioCapability::kAnalogWrite;
 
 struct GpioDescriptor {
     std::uint8_t channel_index;

--- a/core/include/librmcs/spec/rmcs_board_lite/gpio.hpp
+++ b/core/include/librmcs/spec/rmcs_board_lite/gpio.hpp
@@ -6,7 +6,7 @@
 
 #include <librmcs/spec/gpio.hpp>
 
-namespace librmcs::spec::c_board {
+namespace librmcs::spec::rmcs_board_lite {
 
 namespace internal {
 class GpioDescriptors;
@@ -30,15 +30,13 @@ public:
 };
 
 namespace internal {
+
 class GpioDescriptors {
     static constexpr GpioDescriptor kArray[]{
-        {0,                                          kPwmCapabilities},
-        {1,                                          kPwmCapabilities},
-        {2,                                          kPwmCapabilities},
-        {3,                                          kPwmCapabilities},
-        {4,                                          kPwmCapabilities},
-        {5, kPwmCapabilities & ~GpioCapability::kDigitalReadInterrupt},
-        {6,                                          kPwmCapabilities}
+        {0, kDigitalCapabilities},
+        {1, kDigitalCapabilities},
+        {2, kDigitalCapabilities},
+        {3, kDigitalCapabilities},
     };
     static_assert(channel_indices_match_indices(kArray));
 
@@ -55,16 +53,14 @@ public:
 
     static constexpr const GpioDescriptor* end() noexcept { return std::end(kArray); }
 
-    static constexpr const GpioDescriptor& kPwm1 = kArray[0];
-    static constexpr const GpioDescriptor& kPwm2 = kArray[1];
-    static constexpr const GpioDescriptor& kPwm3 = kArray[2];
-    static constexpr const GpioDescriptor& kPwm4 = kArray[3];
-    static constexpr const GpioDescriptor& kPwm5 = kArray[4];
-    static constexpr const GpioDescriptor& kPwm6 = kArray[5];
-    static constexpr const GpioDescriptor& kPwm7 = kArray[6];
+    static constexpr const GpioDescriptor& kUart0Rx = kArray[0];
+    static constexpr const GpioDescriptor& kUart0Tx = kArray[1];
+    static constexpr const GpioDescriptor& kUart1Rx = kArray[2];
+    static constexpr const GpioDescriptor& kUart1Tx = kArray[3];
 };
+
 } // namespace internal
 
 inline constexpr internal::GpioDescriptors kGpioDescriptors{};
 
-} // namespace librmcs::spec::c_board
+} // namespace librmcs::spec::rmcs_board_lite

--- a/core/include/librmcs/spec/rmcs_board_pro/gpio.hpp
+++ b/core/include/librmcs/spec/rmcs_board_pro/gpio.hpp
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+
+#include <librmcs/spec/gpio.hpp>
+
+namespace librmcs::spec::rmcs_board_pro {
+
+namespace internal {
+class GpioDescriptors;
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
+class GpioDescriptor : public spec::GpioDescriptor {
+    friend internal::GpioDescriptors;
+    constexpr GpioDescriptor(uint8_t channel_index, GpioCapability capability_mask)
+        : spec::GpioDescriptor(channel_index, capability_mask) {}
+
+public:
+    GpioDescriptor(const GpioDescriptor&) = delete;
+    GpioDescriptor& operator=(const GpioDescriptor&) = delete;
+    GpioDescriptor(GpioDescriptor&&) = delete;
+    GpioDescriptor& operator=(GpioDescriptor&&) = delete;
+
+    [[nodiscard]] constexpr bool operator==(const GpioDescriptor& other) const noexcept {
+        return channel_index == other.channel_index;
+    }
+};
+
+namespace internal {
+
+class GpioDescriptors {
+    static constexpr GpioDescriptor kArray[]{
+        { 0,     kPwmCapabilities},
+        { 1,     kPwmCapabilities},
+        { 2,     kPwmCapabilities},
+        { 3,     kPwmCapabilities},
+        { 4, kDigitalCapabilities},
+        { 5, kDigitalCapabilities},
+        { 6, kDigitalCapabilities},
+        { 7, kDigitalCapabilities},
+        { 8, kDigitalCapabilities},
+        { 9, kDigitalCapabilities},
+        {10, kDigitalCapabilities},
+        {11, kDigitalCapabilities},
+        {12, kDigitalCapabilities},
+        {13, kDigitalCapabilities},
+        {14, kDigitalCapabilities},
+        {15, kDigitalCapabilities},
+        {16, kDigitalCapabilities},
+    };
+    static_assert(channel_indices_match_indices(kArray));
+
+public:
+    constexpr GpioDescriptors() = default;
+
+    static constexpr std::size_t size() noexcept { return std::size(kArray); }
+
+    static constexpr const GpioDescriptor& operator[](std::size_t channel_index) noexcept {
+        return kArray[channel_index];
+    }
+
+    static constexpr const GpioDescriptor* begin() noexcept { return std::begin(kArray); }
+
+    static constexpr const GpioDescriptor* end() noexcept { return std::end(kArray); }
+
+    static constexpr const GpioDescriptor& kPwm0 = kArray[0];
+    static constexpr const GpioDescriptor& kPwm1 = kArray[1];
+    static constexpr const GpioDescriptor& kPwm2 = kArray[2];
+    static constexpr const GpioDescriptor& kPwm3 = kArray[3];
+
+    static constexpr const GpioDescriptor& kSpiI2cSocket0 = kArray[4];
+    static constexpr const GpioDescriptor& kSpiI2cSocket1 = kArray[5];
+    static constexpr const GpioDescriptor& kSpiI2cSocket2 = kArray[6];
+    static constexpr const GpioDescriptor& kSpiI2cSocket3 = kArray[7];
+    static constexpr const GpioDescriptor& kSpiI2cSocket4 = kArray[8];
+    static constexpr const GpioDescriptor& kSpiI2cSocket5 = kArray[9];
+    static constexpr const GpioDescriptor& kSpiI2cSocket6 = kArray[10];
+
+    static constexpr const GpioDescriptor& kUart0Rx = kArray[11];
+    static constexpr const GpioDescriptor& kUart0Tx = kArray[12];
+    static constexpr const GpioDescriptor& kUart1Rx = kArray[13];
+    static constexpr const GpioDescriptor& kUart1Tx = kArray[14];
+    static constexpr const GpioDescriptor& kUart2Rx = kArray[15];
+    static constexpr const GpioDescriptor& kUart2Tx = kArray[16];
+};
+
+} // namespace internal
+
+inline constexpr internal::GpioDescriptors kGpioDescriptors{};
+
+} // namespace librmcs::spec::rmcs_board_pro

--- a/core/src/protocol/deserializer.cpp
+++ b/core/src/protocol/deserializer.cpp
@@ -153,7 +153,7 @@ coroutine::LifoTask<bool> Deserializer::process_uart_field(FieldId field_id) {
 
 coroutine::LifoTask<bool> Deserializer::process_gpio_field(FieldId) {
     GpioHeader::PayloadEnum payload_type;
-    std::uint8_t channel = 0;
+    std::uint8_t channel_index = 0;
     data::GpioPull pull = data::GpioPull::kNone;
     {
         const auto* header_bytes = co_await peek_bytes(sizeof(GpioHeader));
@@ -162,7 +162,7 @@ coroutine::LifoTask<bool> Deserializer::process_gpio_field(FieldId) {
 
         auto header = GpioHeader::CRef{header_bytes};
         payload_type = header.get<GpioHeader::PayloadType>();
-        channel = header.get<GpioHeader::Channel>();
+        channel_index = header.get<GpioHeader::ChannelIndex>();
         pull = header.get<GpioHeader::Pull>();
         consume_peeked();
     }
@@ -171,9 +171,8 @@ coroutine::LifoTask<bool> Deserializer::process_gpio_field(FieldId) {
     case GpioHeader::PayloadEnum::kDigitalWriteLow:
     case GpioHeader::PayloadEnum::kDigitalWriteHigh: {
         data::GpioDigitalDataView data_view{};
-        data_view.channel = channel;
         data_view.high = payload_type == GpioHeader::PayloadEnum::kDigitalWriteHigh;
-        callback_.gpio_digital_data_deserialized_callback(data_view);
+        callback_.gpio_digital_data_deserialized_callback(channel_index, data_view);
         break;
     }
     case GpioHeader::PayloadEnum::kAnalogWrite: {
@@ -183,11 +182,10 @@ coroutine::LifoTask<bool> Deserializer::process_gpio_field(FieldId) {
 
         auto payload = GpioAnalogPayload::CRef{payload_bytes};
         data::GpioAnalogDataView data_view{};
-        data_view.channel = channel;
         data_view.value = payload.get<GpioAnalogPayload::Value>();
         consume_peeked();
 
-        callback_.gpio_analog_data_deserialized_callback(data_view);
+        callback_.gpio_analog_data_deserialized_callback(channel_index, data_view);
         break;
     }
     case GpioHeader::PayloadEnum::kDigitalRead:
@@ -198,7 +196,6 @@ coroutine::LifoTask<bool> Deserializer::process_gpio_field(FieldId) {
 
         auto payload = GpioReadConfigPayload::CRef{payload_bytes};
         data::GpioReadConfigView data_view{};
-        data_view.channel = channel;
         data_view.asap = payload.get<GpioReadConfigPayload::Asap>();
         data_view.rising_edge = payload.get<GpioReadConfigPayload::RisingEdge>();
         data_view.falling_edge = payload.get<GpioReadConfigPayload::FallingEdge>();
@@ -211,18 +208,17 @@ coroutine::LifoTask<bool> Deserializer::process_gpio_field(FieldId) {
             co_return false;
 
         if (payload_type == GpioHeader::PayloadEnum::kDigitalRead) {
-            callback_.gpio_digital_read_config_deserialized_callback(data_view);
+            callback_.gpio_digital_read_config_deserialized_callback(channel_index, data_view);
         } else {
-            callback_.gpio_analog_read_config_deserialized_callback(data_view);
+            callback_.gpio_analog_read_config_deserialized_callback(channel_index, data_view);
         }
         break;
     }
     case GpioHeader::PayloadEnum::kDigitalReadResultLow:
     case GpioHeader::PayloadEnum::kDigitalReadResultHigh: {
         data::GpioDigitalDataView data_view{};
-        data_view.channel = channel;
         data_view.high = payload_type == GpioHeader::PayloadEnum::kDigitalReadResultHigh;
-        callback_.gpio_digital_data_deserialized_callback(data_view);
+        callback_.gpio_digital_data_deserialized_callback(channel_index, data_view);
         break;
     }
     case GpioHeader::PayloadEnum::kAnalogReadResult: {
@@ -232,11 +228,10 @@ coroutine::LifoTask<bool> Deserializer::process_gpio_field(FieldId) {
 
         auto payload = GpioAnalogPayload::CRef{payload_bytes};
         data::GpioAnalogDataView data_view{};
-        data_view.channel = channel;
         data_view.value = payload.get<GpioAnalogPayload::Value>();
         consume_peeked();
 
-        callback_.gpio_analog_data_deserialized_callback(data_view);
+        callback_.gpio_analog_data_deserialized_callback(channel_index, data_view);
         break;
     }
     default: co_return false;

--- a/core/src/protocol/deserializer.hpp
+++ b/core/src/protocol/deserializer.hpp
@@ -2,6 +2,7 @@
 
 #include <coroutine>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <span>
 #include <utility>
@@ -27,15 +28,17 @@ public:
 
     virtual void uart_deserialized_callback(FieldId id, const data::UartDataView& data) = 0;
 
-    virtual void gpio_digital_data_deserialized_callback(const data::GpioDigitalDataView& data) = 0;
+    virtual void gpio_digital_data_deserialized_callback(
+        uint8_t channel_index, const data::GpioDigitalDataView& data) = 0;
 
-    virtual void gpio_analog_data_deserialized_callback(const data::GpioAnalogDataView& data) = 0;
+    virtual void gpio_analog_data_deserialized_callback(
+        uint8_t channel_index, const data::GpioAnalogDataView& data) = 0;
 
-    virtual void
-        gpio_digital_read_config_deserialized_callback(const data::GpioReadConfigView& data) = 0;
+    virtual void gpio_digital_read_config_deserialized_callback(
+        uint8_t channel_index, const data::GpioReadConfigView& data) = 0;
 
-    virtual void
-        gpio_analog_read_config_deserialized_callback(const data::GpioReadConfigView& data) = 0;
+    virtual void gpio_analog_read_config_deserialized_callback(
+        uint8_t channel_index, const data::GpioReadConfigView& data) = 0;
 
     virtual void accelerometer_deserialized_callback(const data::AccelerometerDataView& data) = 0;
 

--- a/core/src/protocol/protocol.hpp
+++ b/core/src/protocol/protocol.hpp
@@ -95,7 +95,7 @@ struct GpioHeader : utility::Bitfield<2> {
     };
 
     using PayloadType = utility::BitfieldMember<4, 4, PayloadEnum>;
-    using Channel = utility::BitfieldMember<8, 6>;
+    using ChannelIndex = utility::BitfieldMember<8, 6>;
     using Pull = utility::BitfieldMember<14, 2, data::GpioPull>;
 };
 

--- a/core/src/protocol/serializer.hpp
+++ b/core/src/protocol/serializer.hpp
@@ -120,7 +120,9 @@ public:
         return SerializeResult::kSuccess;
     }
 
-    SerializeResult write_gpio_digital_data(const data::GpioDigitalDataView& view) noexcept {
+    SerializeResult write_gpio_digital_data(
+        uint8_t channel_index, const data::GpioDigitalDataView& view) noexcept {
+        utility::assert_debug(channel_index < (1U << GpioHeader::ChannelIndex::kBitWidth));
         const auto payload_type = view.high ? GpioHeader::PayloadEnum::kDigitalWriteHigh
                                             : GpioHeader::PayloadEnum::kDigitalWriteLow;
         const std::size_t required = required_gpio_size(FieldId::kGpio, payload_type);
@@ -136,14 +138,16 @@ public:
         auto header = GpioHeader::Ref(cursor);
         cursor += sizeof(GpioHeader);
         header.set<GpioHeader::PayloadType>(payload_type);
-        header.set<GpioHeader::Channel>(view.channel);
+        header.set<GpioHeader::ChannelIndex>(channel_index);
         header.set<GpioHeader::Pull>(data::GpioPull::kNone);
 
         utility::assert_debug(cursor == dst.data() + dst.size());
         return SerializeResult::kSuccess;
     }
 
-    SerializeResult write_gpio_digital_read_config(const data::GpioReadConfigView& view) noexcept {
+    SerializeResult write_gpio_digital_read_config(
+        uint8_t channel_index, const data::GpioReadConfigView& view) noexcept {
+        utility::assert_debug(channel_index < (1U << GpioHeader::ChannelIndex::kBitWidth));
         LIBRMCS_VERIFY_LIKELY(
             view.period_ms <= ((1U << 13) - 1U), SerializeResult::kInvalidArgument);
 
@@ -161,7 +165,7 @@ public:
         auto header = GpioHeader::Ref(cursor);
         cursor += sizeof(GpioHeader);
         header.set<GpioHeader::PayloadType>(GpioHeader::PayloadEnum::kDigitalRead);
-        header.set<GpioHeader::Channel>(view.channel);
+        header.set<GpioHeader::ChannelIndex>(channel_index);
         header.set<GpioHeader::Pull>(view.pull);
 
         auto payload = GpioReadConfigPayload::Ref(cursor);
@@ -175,7 +179,9 @@ public:
         return SerializeResult::kSuccess;
     }
 
-    SerializeResult write_gpio_analog_data(const data::GpioAnalogDataView& view) noexcept {
+    SerializeResult write_gpio_analog_data(
+        uint8_t channel_index, const data::GpioAnalogDataView& view) noexcept {
+        utility::assert_debug(channel_index < (1U << GpioHeader::ChannelIndex::kBitWidth));
         const std::size_t required =
             required_gpio_size(FieldId::kGpio, GpioHeader::PayloadEnum::kAnalogWrite);
         LIBRMCS_VERIFY_LIKELY(required, SerializeResult::kInvalidArgument);
@@ -190,7 +196,7 @@ public:
         auto header = GpioHeader::Ref(cursor);
         cursor += sizeof(GpioHeader);
         header.set<GpioHeader::PayloadType>(GpioHeader::PayloadEnum::kAnalogWrite);
-        header.set<GpioHeader::Channel>(view.channel);
+        header.set<GpioHeader::ChannelIndex>(channel_index);
         header.set<GpioHeader::Pull>(data::GpioPull::kNone);
 
         auto payload = GpioAnalogPayload::Ref(cursor);
@@ -201,7 +207,9 @@ public:
         return SerializeResult::kSuccess;
     }
 
-    SerializeResult write_gpio_analog_read_config(const data::GpioReadConfigView& view) noexcept {
+    SerializeResult write_gpio_analog_read_config(
+        uint8_t channel_index, const data::GpioReadConfigView& view) noexcept {
+        utility::assert_debug(channel_index < (1U << GpioHeader::ChannelIndex::kBitWidth));
         LIBRMCS_VERIFY_LIKELY(
             view.period_ms <= ((1U << 13) - 1U), SerializeResult::kInvalidArgument);
         LIBRMCS_VERIFY_LIKELY(
@@ -221,7 +229,7 @@ public:
         auto header = GpioHeader::Ref(cursor);
         cursor += sizeof(GpioHeader);
         header.set<GpioHeader::PayloadType>(GpioHeader::PayloadEnum::kAnalogRead);
-        header.set<GpioHeader::Channel>(view.channel);
+        header.set<GpioHeader::ChannelIndex>(channel_index);
         header.set<GpioHeader::Pull>(view.pull);
 
         auto payload = GpioReadConfigPayload::Ref(cursor);
@@ -235,7 +243,9 @@ public:
         return SerializeResult::kSuccess;
     }
 
-    SerializeResult write_gpio_digital_read_result(const data::GpioDigitalDataView& view) noexcept {
+    SerializeResult write_gpio_digital_read_result(
+        uint8_t channel_index, const data::GpioDigitalDataView& view) noexcept {
+        utility::assert_debug(channel_index < (1U << GpioHeader::ChannelIndex::kBitWidth));
         const auto payload_type = view.high ? GpioHeader::PayloadEnum::kDigitalReadResultHigh
                                             : GpioHeader::PayloadEnum::kDigitalReadResultLow;
         const std::size_t required = required_gpio_size(FieldId::kGpio, payload_type);
@@ -251,14 +261,16 @@ public:
         auto header = GpioHeader::Ref(cursor);
         cursor += sizeof(GpioHeader);
         header.set<GpioHeader::PayloadType>(payload_type);
-        header.set<GpioHeader::Channel>(view.channel);
+        header.set<GpioHeader::ChannelIndex>(channel_index);
         header.set<GpioHeader::Pull>(data::GpioPull::kNone);
 
         utility::assert_debug(cursor == dst.data() + dst.size());
         return SerializeResult::kSuccess;
     }
 
-    SerializeResult write_gpio_analog_read_result(const data::GpioAnalogDataView& view) noexcept {
+    SerializeResult write_gpio_analog_read_result(
+        uint8_t channel_index, const data::GpioAnalogDataView& view) noexcept {
+        utility::assert_debug(channel_index < (1U << GpioHeader::ChannelIndex::kBitWidth));
         const std::size_t required =
             required_gpio_size(FieldId::kGpio, GpioHeader::PayloadEnum::kAnalogReadResult);
         LIBRMCS_VERIFY_LIKELY(required, SerializeResult::kInvalidArgument);
@@ -273,7 +285,7 @@ public:
         auto header = GpioHeader::Ref(cursor);
         cursor += sizeof(GpioHeader);
         header.set<GpioHeader::PayloadType>(GpioHeader::PayloadEnum::kAnalogReadResult);
-        header.set<GpioHeader::Channel>(view.channel);
+        header.set<GpioHeader::ChannelIndex>(channel_index);
         header.set<GpioHeader::Pull>(data::GpioPull::kNone);
 
         auto payload = GpioAnalogPayload::Ref(cursor);

--- a/firmware/c_board/CMakeLists.txt
+++ b/firmware/c_board/CMakeLists.txt
@@ -35,6 +35,7 @@ add_subdirectory("${LIBRMCS_STM32_CUBEMX_ROOT}/cmake/stm32cubemx" SYSTEM)
 
 function(c_board_apply_target_options target linker_file)
     target_include_directories(${target} PRIVATE
+        ${LIBRMCS_PROJECT_ROOT}/core/include
         ${LIBRMCS_PROJECT_ROOT}
     )
 

--- a/firmware/c_board/app/src/gpio/gpio.hpp
+++ b/firmware/c_board/app/src/gpio/gpio.hpp
@@ -57,6 +57,9 @@ public:
 
     void handle_digital_read(uint8_t channel_index, const data::GpioReadConfigView& data) {
         configure_digital_input_mode(channel_index, data);
+
+        if (data.asap)
+            publish_digital_input_sample(channel_index);
     }
 
     void poll_periodic_input_samples() {
@@ -64,13 +67,13 @@ public:
 
         for (std::size_t channel_index = 0; channel_index < kChannelCount; ++channel_index) {
             auto& state = channel_states_[channel_index];
-            if (state.mode != GpioMode::kDigitalInput || state.period == kNoPeriod)
+            if (state.mode != GpioMode::kDigitalInput || state.sample_period == kNoPeriod)
                 continue;
-            if (!timer::timer->check_expired(state.next_sample_time, state.period))
+            if (!timer::timer->check_reached(state.next_sample_deadline))
                 continue;
 
             publish_digital_input_sample(static_cast<uint8_t>(channel_index));
-            state.next_sample_time = now;
+            state.next_sample_deadline = now + state.sample_period;
         }
     }
 
@@ -94,8 +97,8 @@ private:
         bool rising_edge = false;
         bool falling_edge = false;
         data::GpioPull pull = data::GpioPull::kNone;
-        timer::Timer::Duration period = timer::Timer::Duration::zero();
-        timer::Timer::TimePoint next_sample_time;
+        timer::Timer::Duration sample_period = timer::Timer::Duration::zero();
+        timer::Timer::TimePoint next_sample_deadline;
     };
 
     struct ChannelHardware {
@@ -122,31 +125,27 @@ private:
     void configure_digital_input_mode(uint8_t channel_index, const data::GpioReadConfigView& data) {
         auto& state = channel_state(channel_index);
 
-        const auto& asap = data.asap;
         auto rising_edge = data.rising_edge;
         auto falling_edge = data.falling_edge;
         const auto pull = data.pull;
-        const auto period =
+        const auto sample_period =
             (data.period_ms == 0)
                 ? kNoPeriod
                 : timer::Timer::to_duration_checked(std::chrono::milliseconds{data.period_ms});
 
         if (state.mode != GpioMode::kDigitalInput //
             || state.rising_edge != rising_edge || state.falling_edge != falling_edge
-            || state.pull != pull || state.period != period) {
+            || state.pull != pull || state.sample_period != sample_period) {
 
             state.mode = GpioMode::kDigitalInput;
             state.rising_edge = rising_edge;
             state.falling_edge = falling_edge;
             state.pull = pull;
-            state.period = period;
-            state.next_sample_time = timer::timer->timepoint();
+            state.sample_period = sample_period;
+            state.next_sample_deadline = timer::timer->timepoint();
 
             configure_hal_gpio_input(channel_index, rising_edge, falling_edge, pull);
         }
-
-        if (asap)
-            publish_digital_input_sample(channel_index);
     }
 
     void set_pwm_compare(uint8_t channel_index, uint32_t compare) {

--- a/firmware/c_board/app/src/gpio/gpio.hpp
+++ b/firmware/c_board/app/src/gpio/gpio.hpp
@@ -1,13 +1,16 @@
 #pragma once
 
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
+#include <iterator>
 
 #include <gpio.h>
 #include <main.h>
 #include <tim.h>
 
 #include "core/include/librmcs/data/datas.hpp"
+#include "core/include/librmcs/spec/c_board/gpio.hpp"
 #include "core/src/protocol/serializer.hpp"
 #include "core/src/utility/assert.hpp"
 #include "core/src/utility/immovable.hpp"
@@ -35,66 +38,52 @@ public:
         HAL_NVIC_SetPriority(EXTI15_10_IRQn, 4, 0);
         HAL_NVIC_EnableIRQ(EXTI15_10_IRQn);
 
-        for (uint8_t i = 1; i <= 7; i++) {
-            set_pwm_compare(i, 0);
-            configure_digital_input_mode({
-                .channel = i,
-                .period_ms = 0,
-                .asap = false,
-                .rising_edge = false,
-                .falling_edge = false,
-            });
+        constexpr data::GpioReadConfigView k_default_input_config{};
+        for (const auto& gpio : spec::c_board::kGpioDescriptors) {
+            set_pwm_compare(gpio.channel_index, 0);
+            configure_digital_input_mode(gpio.channel_index, k_default_input_config);
         }
     }
 
-    void handle_digital_write(const data::GpioDigitalDataView& data) {
-        if (!is_supported_channel(data.channel))
-            return;
-
-        configure_output_mode(data.channel);
-        set_pwm_compare(data.channel, data.high ? kPwmCounterPeriod : 0);
+    void handle_digital_write(uint8_t channel_index, const data::GpioDigitalDataView& data) {
+        configure_output_mode(channel_index);
+        set_pwm_compare(channel_index, data.high ? kPwmCounterPeriod : 0);
     }
 
-    void handle_analog_write(const data::GpioAnalogDataView& data) {
-        if (!is_supported_channel(data.channel))
-            return;
-
-        configure_output_mode(data.channel);
-        set_pwm_compare(data.channel, duty16_to_pwm_compare(data.value));
+    void handle_analog_write(uint8_t channel_index, const data::GpioAnalogDataView& data) {
+        configure_output_mode(channel_index);
+        set_pwm_compare(channel_index, duty16_to_pwm_compare(data.value));
     }
 
-    void handle_digital_read(const data::GpioReadConfigView& data) {
-        if (!is_supported_channel(data.channel))
-            return;
-
-        configure_digital_input_mode(data);
+    void handle_digital_read(uint8_t channel_index, const data::GpioReadConfigView& data) {
+        configure_digital_input_mode(channel_index, data);
     }
 
     void poll_periodic_input_samples() {
         const auto now = timer::timer->timepoint();
 
-        for (uint8_t channel = 1; channel <= 7; ++channel) {
-            auto& state = channel_states_[channel - 1];
+        for (std::size_t channel_index = 0; channel_index < kChannelCount; ++channel_index) {
+            auto& state = channel_states_[channel_index];
             if (state.mode != GpioMode::kDigitalInput || state.period == kNoPeriod)
                 continue;
             if (!timer::timer->check_expired(state.next_sample_time, state.period))
                 continue;
 
-            publish_digital_input_sample(channel);
+            publish_digital_input_sample(static_cast<uint8_t>(channel_index));
             state.next_sample_time = now;
         }
     }
 
     void handle_input_edge_interrupt(uint16_t gpio_pin) {
-        const uint8_t channel = channel_from_exti_line(exti_line_from_pin(gpio_pin));
-        if (!channel)
+        const uint8_t channel_index = channel_index_from_exti_line(exti_line_from_pin(gpio_pin));
+        if (channel_index == kInvalidChannelIndex)
             return;
 
-        auto& state = channel_states_[channel - 1];
+        auto& state = channel_state(channel_index);
         if (state.mode != GpioMode::kDigitalInput || (!state.rising_edge && !state.falling_edge))
             return;
 
-        publish_digital_input_sample(channel);
+        publish_digital_input_sample(channel_index);
     }
 
 private:
@@ -118,19 +107,20 @@ private:
 
     static constexpr uint32_t kPwmCounterPeriod = 60000;
     static constexpr auto kNoPeriod = timer::Timer::Duration::zero();
+    static constexpr std::size_t kChannelCount = std::size(spec::c_board::kGpioDescriptors);
+    static constexpr uint8_t kInvalidChannelIndex = 0xFFU;
 
-    void configure_output_mode(uint8_t channel) {
-        auto& state = channel_states_[channel - 1];
+    void configure_output_mode(uint8_t channel_index) {
+        auto& state = channel_state(channel_index);
         if (state.mode == GpioMode::kOutput)
             return;
 
         state.mode = GpioMode::kOutput;
-        configure_hal_gpio_output(channel);
+        configure_hal_gpio_output(channel_index);
     }
 
-    void configure_digital_input_mode(const data::GpioReadConfigView& data) {
-        const auto& channel = data.channel;
-        auto& state = channel_states_[channel - 1];
+    void configure_digital_input_mode(uint8_t channel_index, const data::GpioReadConfigView& data) {
+        auto& state = channel_state(channel_index);
 
         const auto& asap = data.asap;
         auto rising_edge = data.rising_edge;
@@ -140,12 +130,6 @@ private:
             (data.period_ms == 0)
                 ? kNoPeriod
                 : timer::Timer::to_duration_checked(std::chrono::milliseconds{data.period_ms});
-
-        if (channel == 6) {
-            // Channel 6 (PI6) shares EXTI line 6 with Channel 5 (PC6),
-            // so Channel 6 does not support EXTI.
-            rising_edge = falling_edge = false;
-        }
 
         if (state.mode != GpioMode::kDigitalInput //
             || state.rising_edge != rising_edge || state.falling_edge != falling_edge
@@ -158,20 +142,20 @@ private:
             state.period = period;
             state.next_sample_time = timer::timer->timepoint();
 
-            configure_hal_gpio_input(channel, rising_edge, falling_edge, pull);
+            configure_hal_gpio_input(channel_index, rising_edge, falling_edge, pull);
         }
 
         if (asap)
-            publish_digital_input_sample(channel);
+            publish_digital_input_sample(channel_index);
     }
 
-    void set_pwm_compare(uint8_t channel, uint32_t compare) {
-        const auto& hardware = channel_hardware(channel);
+    void set_pwm_compare(uint8_t channel_index, uint32_t compare) {
+        const auto& hardware = channel_hardware(channel_index);
         *hardware.compare_register = compare;
     }
 
-    void configure_hal_gpio_output(uint8_t channel) {
-        const auto& hardware = channel_hardware(channel);
+    void configure_hal_gpio_output(uint8_t channel_index) {
+        const auto& hardware = channel_hardware(channel_index);
 
         GPIO_InitTypeDef gpio_init = {};
         gpio_init.Pin = hardware.gpio_pin;
@@ -183,8 +167,8 @@ private:
     }
 
     void configure_hal_gpio_input(
-        uint8_t channel, bool rising_edge, bool falling_edge, data::GpioPull pull) {
-        const auto& hardware = channel_hardware(channel);
+        uint8_t channel_index, bool rising_edge, bool falling_edge, data::GpioPull pull) {
+        const auto& hardware = channel_hardware(channel_index);
 
         GPIO_InitTypeDef gpio_init = {};
         gpio_init.Pin = hardware.gpio_pin;
@@ -202,13 +186,13 @@ private:
         HAL_GPIO_Init(hardware.gpio_port, &gpio_init);
     }
 
-    void publish_digital_input_sample(uint8_t channel) {
-        const auto& hardware = channel_hardware(channel);
+    void publish_digital_input_sample(uint8_t channel_index) {
+        const auto& hardware = channel_hardware(channel_index);
         const bool high = HAL_GPIO_ReadPin(hardware.gpio_port, hardware.gpio_pin) == GPIO_PIN_SET;
 
         auto& serializer = usb::get_serializer();
         core::utility::assert_debug(
-            serializer.write_gpio_digital_read_result({.channel = channel, .high = high})
+            serializer.write_gpio_digital_read_result(channel_index, {.high = high})
             != core::protocol::Serializer::SerializeResult::kInvalidArgument);
     }
 
@@ -224,24 +208,29 @@ private:
         return line;
     }
 
-    static uint8_t channel_from_exti_line(uint8_t exti_line) {
+    static uint8_t channel_index_from_exti_line(uint8_t exti_line) {
         switch (exti_line) {
-        case 9: return 1;
-        case 11: return 2;
-        case 13: return 3;
-        case 14: return 4;
-        case 6: return 5;
-        case 7: return 7;
-        default: return 0;
+        case 9: return spec::c_board::kGpioDescriptors.kPwm1.channel_index;
+        case 11: return spec::c_board::kGpioDescriptors.kPwm2.channel_index;
+        case 13: return spec::c_board::kGpioDescriptors.kPwm3.channel_index;
+        case 14: return spec::c_board::kGpioDescriptors.kPwm4.channel_index;
+        case 6: return spec::c_board::kGpioDescriptors.kPwm5.channel_index;
+        case 7: return spec::c_board::kGpioDescriptors.kPwm7.channel_index;
+        default: return kInvalidChannelIndex;
         }
     }
 
-    const ChannelHardware& channel_hardware(uint8_t channel) const {
-        core::utility::assert_debug_lazy([&]() noexcept { return is_supported_channel(channel); });
-        return channel_hardware_[channel - 1];
+    ChannelState& channel_state(uint8_t channel_index) {
+        const auto index = static_cast<std::size_t>(channel_index);
+        core::utility::assert_debug(index < kChannelCount);
+        return channel_states_[index];
     }
 
-    static bool is_supported_channel(uint8_t channel) { return channel >= 1 && channel <= 7; }
+    const ChannelHardware& channel_hardware(uint8_t channel_index) const {
+        const auto index = static_cast<std::size_t>(channel_index);
+        core::utility::assert_debug(index < kChannelCount);
+        return channel_hardware_[index];
+    }
 
     static uint32_t duty16_to_pwm_compare(uint16_t duty) {
         return ((static_cast<uint32_t>(duty) * kPwmCounterPeriod) + 32767U) / 65535U;
@@ -256,7 +245,7 @@ private:
         }
     }
 
-    const ChannelHardware channel_hardware_[7]{
+    const ChannelHardware channel_hardware_[kChannelCount]{
         {
          .gpio_port = CHANNEL1_GPIO_Port,
          .gpio_pin = CHANNEL1_Pin,
@@ -301,7 +290,7 @@ private:
          },
     };
 
-    ChannelState channel_states_[7];
+    ChannelState channel_states_[kChannelCount];
 };
 
 inline constinit Gpio::Lazy gpio;

--- a/firmware/c_board/app/src/timer/timer.hpp
+++ b/firmware/c_board/app/src/timer/timer.hpp
@@ -30,7 +30,7 @@ public:
     using TimePoint48 = std::chrono::time_point<uint64_t, Duration48>;
 
     // Keep the true-window at least half-cycle for stateless expiration checks.
-    static constexpr uint64_t kMaxDurationTicks = uint64_t{1} << 31;
+    static constexpr uint32_t kMaxDurationTicks = uint32_t{1} << 31;
     static constexpr uint64_t kMaxDuration48Ticks = uint64_t{1} << 47;
 
     static constexpr uint64_t kCounter48Mask = 0xFFFFFFFFFFFFULL;
@@ -67,6 +67,13 @@ public:
         return elapsed_duration >= delay;
     }
 
+    [[nodiscard]] bool check_reached(TimePoint deadline) const {
+        const uint32_t deadline_ticks = deadline.time_since_epoch().count();
+        const uint32_t now_ticks = timepoint().time_since_epoch().count();
+        const uint32_t elapsed_ticks = now_ticks - deadline_ticks;
+        return elapsed_ticks < kMaxDurationTicks;
+    }
+
     [[nodiscard]] bool check_expired(TimePoint48 start_point, Duration48 delay) const {
         core::utility::assert_debug(delay.count() <= kMaxDuration48Ticks);
 
@@ -93,7 +100,7 @@ public:
         using InputDuration = std::chrono::duration<uint64_t, Period>;
         const InputDuration duration_u64{count};
 
-        constexpr Duration max_duration{static_cast<uint32_t>(kMaxDurationTicks)};
+        constexpr Duration max_duration{kMaxDurationTicks};
         const InputDuration max_input_duration =
             std::chrono::duration_cast<InputDuration>(max_duration);
 

--- a/firmware/c_board/app/src/usb/vendor.hpp
+++ b/firmware/c_board/app/src/usb/vendor.hpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <span>
 
 #include <class/vendor/vendor_device.h>
@@ -10,6 +11,8 @@
 #include <tusb.h>
 
 #include "core/include/librmcs/data/datas.hpp"
+#include "core/include/librmcs/spec/c_board/gpio.hpp"
+#include "core/include/librmcs/spec/gpio.hpp"
 #include "core/src/protocol/deserializer.hpp"
 #include "core/src/protocol/protocol.hpp"
 #include "core/src/protocol/serializer.hpp"
@@ -31,6 +34,7 @@ public:
     using Lazy = utility::Lazy<Vendor>;
 
     static constexpr size_t kMaxPacketSize = 64;
+    static constexpr std::size_t kGpioChannelCount = std::size(spec::c_board::kGpioDescriptors);
 
     Vendor() {
         usb::usb_descriptors.init();
@@ -101,21 +105,45 @@ private:
         }
     }
 
-    void gpio_digital_data_deserialized_callback(const data::GpioDigitalDataView& data) override {
-        gpio::gpio->handle_digital_write(data);
+    void gpio_digital_data_deserialized_callback(
+        uint8_t channel_index, const data::GpioDigitalDataView& data) override {
+        if (channel_index >= kGpioChannelCount)
+            return;
+
+        const auto& gpio = spec::c_board::kGpioDescriptors[channel_index];
+        if (!gpio.supports(spec::GpioCapability::kDigitalWrite))
+            return;
+
+        gpio::gpio->handle_digital_write(channel_index, data);
     }
 
-    void gpio_analog_data_deserialized_callback(const data::GpioAnalogDataView& data) override {
-        gpio::gpio->handle_analog_write(data);
+    void gpio_analog_data_deserialized_callback(
+        uint8_t channel_index, const data::GpioAnalogDataView& data) override {
+        if (channel_index >= kGpioChannelCount)
+            return;
+
+        const auto& gpio = spec::c_board::kGpioDescriptors[channel_index];
+        if (!gpio.supports(spec::GpioCapability::kAnalogWrite))
+            return;
+
+        gpio::gpio->handle_analog_write(channel_index, data);
     }
 
     void gpio_digital_read_config_deserialized_callback(
-        const data::GpioReadConfigView& data) override {
-        gpio::gpio->handle_digital_read(data);
+        uint8_t channel_index, const data::GpioReadConfigView& data) override {
+        if (channel_index >= kGpioChannelCount)
+            return;
+
+        const auto& gpio = spec::c_board::kGpioDescriptors[channel_index];
+        if (!data.supported(gpio))
+            return;
+
+        gpio::gpio->handle_digital_read(channel_index, data);
     }
 
     void gpio_analog_read_config_deserialized_callback(
-        const data::GpioReadConfigView& data) override {
+        uint8_t channel_index, const data::GpioReadConfigView& data) override {
+        (void)channel_index;
         (void)data;
     }
 

--- a/firmware/rmcs_board/app/CMakeLists.txt
+++ b/firmware/rmcs_board/app/CMakeLists.txt
@@ -61,6 +61,7 @@ sdk_compile_definitions(-DCFG_TUSB_MCU=OPT_MCU_HPM)
 sdk_compile_definitions(-DUSB_HOST_MCU_CORE=HPM_CORE0)
 
 sdk_inc("${CMAKE_CURRENT_SOURCE_DIR}/include")
+sdk_app_inc("${LIBRMCS_PROJECT_ROOT}/core/include")
 sdk_app_inc("${LIBRMCS_PROJECT_ROOT}")
 
 file(GLOB_RECURSE PROJECT_SOURCE CONFIGURE_DEPENDS

--- a/firmware/rmcs_board/app/src/app.cpp
+++ b/firmware/rmcs_board/app/src/app.cpp
@@ -5,6 +5,7 @@
 #include <hpm_dma_mgr.h>
 
 #include "firmware/rmcs_board/app/src/can/can.hpp"
+#include "firmware/rmcs_board/app/src/gpio/gpio.hpp"
 #include "firmware/rmcs_board/app/src/spi/bmi088/accel.hpp"
 #include "firmware/rmcs_board/app/src/spi/bmi088/gyro.hpp"
 #include "firmware/rmcs_board/app/src/uart/uart.hpp"
@@ -33,6 +34,8 @@ App::App() {
     for (auto& board_uart : uart::uart_array)
         board_uart.init();
 
+    gpio::gpio.init();
+
     spi::bmi088::accelerometer.init();
     spi::bmi088::gyroscope.init();
 }
@@ -46,6 +49,7 @@ App::App() {
 
         for (auto& board_uart : uart::uart_array)
             board_uart->try_transmit();
+        gpio::gpio->poll_periodic_input_samples();
     }
 }
 

--- a/firmware/rmcs_board/app/src/gpio/analog_gpio_pin.hpp
+++ b/firmware/rmcs_board/app/src/gpio/analog_gpio_pin.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <cstdint>
+
+#include <hpm_common.h> // IWYU pragma: keep
+#include <hpm_gpio_drv.h>
+#include <hpm_ioc_regs.h>
+#include <hpm_pwm_drv.h>
+#include <hpm_pwm_regs.h>
+
+#include "core/src/utility/assert.hpp"
+#include "firmware/rmcs_board/app/src/gpio/gpio_pin.hpp"
+
+namespace librmcs::firmware {
+
+class AnalogGpioPin : public GpioPin {
+public:
+    constexpr AnalogGpioPin(const GpioPin& pin) // NOLINT(google-explicit-constructor)
+        : GpioPin(pin)
+        , pwm_base_(0)
+        , pwm_ioc_function_(0)
+        , pwm_output_index_(0) {}
+
+    constexpr AnalogGpioPin(
+        const GpioPin& pin, uintptr_t pwm_base, uint32_t pwm_ioc_function, uint8_t pwm_output_index)
+        : GpioPin(pin)
+        , pwm_base_(pwm_base)
+        , pwm_ioc_function_(static_cast<uint8_t>(pwm_ioc_function))
+        , pwm_output_index_(pwm_output_index) {
+        core::utility::assert_debug(pwm_ioc_function < 32 && pwm_output_index < 8);
+    }
+
+    [[nodiscard]] constexpr bool supports_pwm() const noexcept { return pwm_base_ != 0; }
+
+    void configure_as_gpio() const {
+        configure_controller();
+        configure_ioc_function();
+    }
+
+    void configure_as_pwm() const {
+        core::utility::assert_debug(supports_pwm());
+        configure_controller();
+        configure_ioc_function(pwm_ioc_function_);
+    }
+
+    void disable_interrupt() const {
+        gpio_disable_pin_interrupt(gpio_instance(), port(), pin());
+        clear_interrupt_flag();
+    }
+
+    void update_pwm_compare_edge_aligned(uint32_t compare_value) const {
+        core::utility::assert_debug(supports_pwm());
+        pwm_update_raw_cmp_edge_aligned(pwm_instance(), pwm_output_index_, compare_value);
+    }
+
+    hpm_stat_t setup_pwm_waveform_edge_aligned(uint32_t reload, pwm_config_t& pwm_config) const {
+        core::utility::assert_debug(supports_pwm());
+
+        pwm_cmp_config_t cmp_config{};
+        pwm_get_default_cmp_config(pwm_instance(), &cmp_config);
+        cmp_config.cmp = reload + 1;
+
+        return pwm_setup_waveform(
+            pwm_instance(), pwm_output_index_, &pwm_config, pwm_output_index_, &cmp_config, 1);
+    }
+
+private:
+    PWM_Type* pwm_instance() const { return reinterpret_cast<PWM_Type*>(pwm_base_); }
+
+    uintptr_t pwm_base_;
+
+    uint8_t pwm_ioc_function_;
+    uint8_t pwm_output_index_;
+
+    static_assert(IOC_PAD_FUNC_CTL_ALT_SELECT_SET(31) == 31);
+};
+
+} // namespace librmcs::firmware

--- a/firmware/rmcs_board/app/src/gpio/gpio.cpp
+++ b/firmware/rmcs_board/app/src/gpio/gpio.cpp
@@ -1,0 +1,11 @@
+#include "firmware/rmcs_board/app/src/gpio/gpio.hpp"
+
+#include <cstdint>
+
+#include "board_app.hpp"
+
+namespace librmcs::firmware::board {
+
+void gpio_irq_handler(uint32_t port_index) { gpio::gpio->handle_port_interrupt(port_index); }
+
+} // namespace librmcs::firmware::board

--- a/firmware/rmcs_board/app/src/gpio/gpio.hpp
+++ b/firmware/rmcs_board/app/src/gpio/gpio.hpp
@@ -1,0 +1,305 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <hpm_clock_drv.h>
+#include <hpm_common.h>
+#include <hpm_gpio_drv.h>
+#include <hpm_gpio_regs.h>
+#include <hpm_ioc_regs.h>
+#include <hpm_mchtmr_drv.h>
+#include <hpm_pwm_drv.h>
+#include <hpm_soc.h>
+#include <hpm_soc_irq.h>
+
+#include "board_app.hpp"
+#include "core/include/librmcs/data/datas.hpp"
+#include "core/src/protocol/serializer.hpp"
+#include "core/src/utility/assert.hpp"
+#include "core/src/utility/immovable.hpp"
+#include "firmware/rmcs_board/app/src/gpio/analog_gpio_pin.hpp"
+#include "firmware/rmcs_board/app/src/usb/helper.hpp"
+#include "firmware/rmcs_board/app/src/utility/lazy.hpp"
+
+namespace librmcs::firmware::gpio {
+
+class Gpio : private core::utility::Immovable {
+public:
+    using Lazy = utility::Lazy<Gpio>;
+
+    Gpio()
+        : mchtmr_frequency_hz_(clock_get_frequency(clock_mchtmr0)) {
+        board::init_gpio_pins();
+    }
+
+    void handle_digital_write(uint8_t channel_index, const data::GpioDigitalDataView& data) {
+        configure_digital_output_mode(channel_index, data.high);
+    }
+
+    void handle_analog_write(uint8_t channel_index, const data::GpioAnalogDataView& data) {
+        configure_pwm_output_mode(channel_index);
+        channel_hardware(channel_index)
+            .update_pwm_compare_edge_aligned(duty16_to_pwm_compare(data.value));
+    }
+
+    void handle_digital_read(uint8_t channel_index, const data::GpioReadConfigView& data) {
+        configure_digital_input_mode(channel_index, data);
+
+        if (data.asap)
+            publish_digital_input_sample(channel_index);
+    }
+
+    void poll_periodic_input_samples() {
+        const uint64_t now = now_ticks();
+
+        for (std::size_t channel_index = 0; channel_index < board::spec::kGpioDescriptors.size();
+             ++channel_index) {
+            auto& state = channel_states_[channel_index];
+            if (state.mode != ChannelMode::kDigitalInput || state.period_ticks == 0)
+                continue;
+            if (now < state.next_sample_tick)
+                continue;
+
+            publish_digital_input_sample(static_cast<uint8_t>(channel_index));
+            state.next_sample_tick = now + state.period_ticks;
+        }
+    }
+
+    void handle_port_interrupt(uint32_t port_index) {
+        for (std::size_t channel_index = 0; channel_index < board::spec::kGpioDescriptors.size();
+             ++channel_index) {
+            const auto& hardware = channel_hardware(static_cast<uint8_t>(channel_index));
+            if (hardware.port() != port_index)
+                continue;
+            if (!hardware.check_clear_interrupt_flag())
+                continue;
+
+            auto& state = channel_states_[channel_index];
+            if (state.mode != ChannelMode::kDigitalInput
+                || (!state.rising_edge && !state.falling_edge))
+                continue;
+
+            publish_digital_input_sample(static_cast<uint8_t>(channel_index));
+        }
+    }
+
+private:
+    enum class ChannelMode : uint8_t {
+        kUnconfigured = 0,
+        kDigitalOutput = 1,
+        kDigitalInput = 2,
+        kPwmOutput = 3,
+    };
+
+    struct ChannelState {
+        ChannelMode mode = ChannelMode::kUnconfigured;
+        bool rising_edge = false;
+        bool falling_edge = false;
+        data::GpioPull pull = data::GpioPull::kNone;
+        uint64_t period_ticks = 0;
+        uint64_t next_sample_tick = 0;
+    };
+    static constexpr uint32_t kPwmFrequencyHz = 50;
+
+    void configure_digital_output_mode(uint8_t channel_index, bool initial_high) {
+        auto& state = channel_state(channel_index);
+        const auto& hardware = channel_hardware(channel_index);
+
+        if (state.mode != ChannelMode::kDigitalOutput) {
+            prepare_pin_for_digital_output(hardware, initial_high);
+            set_output_mode_state(state, ChannelMode::kDigitalOutput);
+            return;
+        }
+
+        hardware.write_pin(initial_high);
+    }
+
+    ChannelState& channel_state(uint8_t channel_index) {
+        core::utility::assert_debug(channel_index < board::spec::kGpioDescriptors.size());
+        return channel_states_[channel_index];
+    }
+
+    static const AnalogGpioPin& channel_hardware(uint8_t channel_index) {
+        core::utility::assert_debug(channel_index < board::spec::kGpioDescriptors.size());
+        return board::kGpioHardwareDescriptors[channel_index];
+    }
+
+    static void prepare_pin_for_digital_output(const AnalogGpioPin& hardware, bool initial_high) {
+        hardware.disable_interrupt();
+        hardware.configure_as_gpio();
+        hardware.configure_pad_control(0);
+        hardware.write_pin(initial_high);
+        hardware.configure_as_output();
+    }
+
+    void prepare_pin_for_pwm_output(const AnalogGpioPin& hardware) {
+        hardware.disable_interrupt();
+        ensure_pwm_initialized();
+        hardware.configure_pad_control(0);
+        hardware.configure_as_pwm();
+    }
+
+    static void set_output_mode_state(ChannelState& state, ChannelMode mode) {
+        state.mode = mode;
+        state.rising_edge = false;
+        state.falling_edge = false;
+        state.pull = data::GpioPull::kNone;
+        state.period_ticks = 0;
+        state.next_sample_tick = 0;
+    }
+
+    void configure_pwm_output_mode(uint8_t channel_index) {
+        auto& state = channel_state(channel_index);
+        const auto& hardware = channel_hardware(channel_index);
+
+        core::utility::assert_debug(hardware.supports_pwm());
+        if (state.mode == ChannelMode::kPwmOutput)
+            return;
+
+        prepare_pin_for_pwm_output(hardware);
+        set_output_mode_state(state, ChannelMode::kPwmOutput);
+    }
+
+    static void set_digital_input_mode_state(
+        ChannelState& state, const data::GpioReadConfigView& data, uint64_t period_ticks) {
+        state.mode = ChannelMode::kDigitalInput;
+        state.rising_edge = data.rising_edge;
+        state.falling_edge = data.falling_edge;
+        state.pull = data.pull;
+        state.period_ticks = period_ticks;
+        state.next_sample_tick = now_ticks();
+    }
+
+    void ensure_pwm_initialized() {
+        if (pwm_initialized_)
+            return;
+
+        clock_add_to_group(clock_mot0, 0);
+        const uint32_t pwm_clock_hz = clock_get_frequency(clock_mot0);
+        core::utility::assert_always(pwm_clock_hz >= kPwmFrequencyHz);
+
+        pwm_reload_ = pwm_clock_hz / kPwmFrequencyHz;
+        core::utility::assert_always(pwm_reload_ > 1);
+
+        pwm_deinit(HPM_PWM0);
+        pwm_set_reload(HPM_PWM0, 0, pwm_reload_);
+        pwm_set_start_count(HPM_PWM0, 0, 0);
+
+        pwm_config_t pwm_config{};
+        pwm_get_default_pwm_config(HPM_PWM0, &pwm_config);
+        pwm_config.enable_output = true;
+        pwm_config.invert_output = false;
+
+        for (const auto& hardware : board::kGpioHardwareDescriptors) {
+            if (!hardware.supports_pwm())
+                continue;
+
+            core::utility::assert_always(
+                hardware.setup_pwm_waveform_edge_aligned(pwm_reload_, pwm_config)
+                == status_success);
+        }
+
+        pwm_start_counter(HPM_PWM0);
+        pwm_issue_shadow_register_lock_event(HPM_PWM0);
+        pwm_initialized_ = true;
+    }
+
+    [[nodiscard]] uint32_t duty16_to_pwm_compare(uint16_t duty) const {
+        if (duty == 0)
+            return pwm_reload_ + 1;
+        return (static_cast<uint64_t>(pwm_reload_) * (65535U - duty)) / 65535U;
+    }
+
+    void configure_digital_input_mode(uint8_t channel_index, const data::GpioReadConfigView& data) {
+        auto& state = channel_state(channel_index);
+        const uint64_t period_ticks = period_ms_to_ticks(data.period_ms);
+        if (!needs_digital_input_reconfigure(state, data, period_ticks))
+            return;
+
+        const auto& hardware = channel_hardware(channel_index);
+        prepare_pin_for_digital_input(hardware, data.pull);
+        set_digital_input_mode_state(state, data, period_ticks);
+
+        if (data.rising_edge || data.falling_edge)
+            configure_interrupt(hardware, data.rising_edge, data.falling_edge);
+    }
+
+    [[nodiscard]] uint64_t period_ms_to_ticks(uint16_t period_ms) const {
+        if (period_ms == 0)
+            return 0;
+        return (static_cast<uint64_t>(mchtmr_frequency_hz_) * period_ms) / 1000U;
+    }
+
+    static bool needs_digital_input_reconfigure(
+        const ChannelState& state, const data::GpioReadConfigView& data, uint64_t period_ticks) {
+        return state.mode != ChannelMode::kDigitalInput || state.rising_edge != data.rising_edge
+            || state.falling_edge != data.falling_edge || state.pull != data.pull
+            || state.period_ticks != period_ticks;
+    }
+
+    static uint32_t pad_control_from_pull(data::GpioPull pull) {
+        switch (pull) {
+        case data::GpioPull::kNone: return IOC_PAD_PAD_CTL_HYS_SET(1);
+        case data::GpioPull::kUp:
+            return IOC_PAD_PAD_CTL_PE_SET(1) | IOC_PAD_PAD_CTL_PS_SET(1)
+                 | IOC_PAD_PAD_CTL_HYS_SET(1);
+        case data::GpioPull::kDown:
+            return IOC_PAD_PAD_CTL_PE_SET(1) | IOC_PAD_PAD_CTL_PS_SET(0)
+                 | IOC_PAD_PAD_CTL_HYS_SET(1);
+        default: core::utility::assert_failed_debug(); return IOC_PAD_PAD_CTL_HYS_SET(1);
+        }
+    }
+
+    static void prepare_pin_for_digital_input(const AnalogGpioPin& hardware, data::GpioPull pull) {
+        hardware.disable_interrupt();
+        hardware.configure_as_gpio();
+        hardware.configure_pad_control(pad_control_from_pull(pull));
+        hardware.configure_as_input();
+    }
+
+    [[nodiscard]] static uint64_t now_ticks() { return mchtmr_get_count(HPM_MCHTMR); }
+
+    static void
+        configure_interrupt(const AnalogGpioPin& hardware, bool rising_edge, bool falling_edge) {
+        gpio_interrupt_trigger_t trigger = gpio_interrupt_trigger_edge_rising;
+        if (rising_edge && falling_edge) {
+            trigger = gpio_interrupt_trigger_edge_both;
+        } else if (falling_edge) {
+            trigger = gpio_interrupt_trigger_edge_falling;
+        }
+
+        hardware.configure_interrupt(trigger);
+        hardware.clear_interrupt_flag();
+        hardware.enable_interrupt();
+        enable_port_irq(hardware.port());
+    }
+
+    static void enable_port_irq(uint32_t port_index) {
+        switch (port_index) {
+        case GPIO_DI_GPIOA: intc_m_enable_irq_with_priority(IRQn_GPIO0_A, 1); break;
+        case GPIO_DI_GPIOB: intc_m_enable_irq_with_priority(IRQn_GPIO0_B, 1); break;
+        case GPIO_DI_GPIOY: intc_m_enable_irq_with_priority(IRQn_GPIO0_Y, 1); break;
+        default: core::utility::assert_failed_debug();
+        }
+    }
+
+    static void publish_digital_input_sample(uint8_t channel_index) {
+        const auto& hardware = channel_hardware(channel_index);
+        const bool high = hardware.read_pin();
+
+        auto& serializer = usb::get_serializer();
+        core::utility::assert_debug(
+            serializer.write_gpio_digital_read_result(channel_index, {.high = high})
+            != core::protocol::Serializer::SerializeResult::kInvalidArgument);
+    }
+
+    const uint32_t mchtmr_frequency_hz_;
+    uint32_t pwm_reload_ = 0;
+    bool pwm_initialized_ = false;
+    ChannelState channel_states_[board::spec::kGpioDescriptors.size()]{};
+};
+
+inline constinit Gpio::Lazy gpio;
+
+} // namespace librmcs::firmware::gpio

--- a/firmware/rmcs_board/app/src/gpio/gpio_pin.hpp
+++ b/firmware/rmcs_board/app/src/gpio/gpio_pin.hpp
@@ -13,6 +13,8 @@
 #include <hpm_ioc_regs.h>
 #include <hpm_soc.h>
 
+#include "core/src/utility/assert.hpp"
+
 namespace librmcs::firmware {
 
 class GpioPin {
@@ -30,8 +32,7 @@ public:
         , controller_(static_cast<uint32_t>(controller))
         , pad_(pad)
         , pin_(pin) {
-        if (pad >= (1 << 16) || port >= (1 << 4) || pin >= (1 << 5)) [[unlikely]]
-            __builtin_trap();
+        core::utility::assert_debug(pad < (1 << 16) && port < (1 << 4) && pin < (1 << 5));
     }
 
     constexpr gpiom_gpio_t controller() const { return static_cast<gpiom_gpio_t>(controller_); }

--- a/firmware/rmcs_board/app/src/usb/vendor.hpp
+++ b/firmware/rmcs_board/app/src/usb/vendor.hpp
@@ -12,12 +12,14 @@
 
 #include "board_app.hpp"
 #include "core/include/librmcs/data/datas.hpp"
+#include "core/include/librmcs/spec/gpio.hpp"
 #include "core/src/protocol/deserializer.hpp"
 #include "core/src/protocol/protocol.hpp"
 #include "core/src/protocol/serializer.hpp"
 #include "core/src/utility/assert.hpp"
 #include "core/src/utility/immovable.hpp"
 #include "firmware/rmcs_board/app/src/can/can.hpp"
+#include "firmware/rmcs_board/app/src/gpio/gpio.hpp"
 #include "firmware/rmcs_board/app/src/uart/uart.hpp"
 #include "firmware/rmcs_board/app/src/usb/interrupt_safe_buffer.hpp"
 #include "firmware/rmcs_board/app/src/usb/usb_descriptors.hpp"
@@ -117,20 +119,38 @@ private:
 
     void gpio_digital_data_deserialized_callback(
         uint8_t channel_index, const data::GpioDigitalDataView& data) override {
-        (void)channel_index;
-        (void)data;
+        if (channel_index >= board::spec::kGpioDescriptors.size())
+            return;
+
+        const auto& gpio_descriptor = board::spec::kGpioDescriptors[channel_index];
+        if (!gpio_descriptor.supports(spec::GpioCapability::kDigitalWrite))
+            return;
+
+        gpio::gpio->handle_digital_write(channel_index, data);
     }
 
     void gpio_analog_data_deserialized_callback(
         uint8_t channel_index, const data::GpioAnalogDataView& data) override {
-        (void)channel_index;
-        (void)data;
+        if (channel_index >= board::spec::kGpioDescriptors.size())
+            return;
+
+        const auto& gpio_descriptor = board::spec::kGpioDescriptors[channel_index];
+        if (!gpio_descriptor.supports(spec::GpioCapability::kAnalogWrite))
+            return;
+
+        gpio::gpio->handle_analog_write(channel_index, data);
     }
 
     void gpio_digital_read_config_deserialized_callback(
         uint8_t channel_index, const data::GpioReadConfigView& data) override {
-        (void)channel_index;
-        (void)data;
+        if (channel_index >= board::spec::kGpioDescriptors.size())
+            return;
+
+        const auto& gpio_descriptor = board::spec::kGpioDescriptors[channel_index];
+        if (!data.supported(gpio_descriptor))
+            return;
+
+        gpio::gpio->handle_digital_read(channel_index, data);
     }
 
     void gpio_analog_read_config_deserialized_callback(

--- a/firmware/rmcs_board/app/src/usb/vendor.hpp
+++ b/firmware/rmcs_board/app/src/usb/vendor.hpp
@@ -115,21 +115,27 @@ private:
         }
     }
 
-    void gpio_digital_data_deserialized_callback(const data::GpioDigitalDataView& data) override {
+    void gpio_digital_data_deserialized_callback(
+        uint8_t channel_index, const data::GpioDigitalDataView& data) override {
+        (void)channel_index;
         (void)data;
     }
 
-    void gpio_analog_data_deserialized_callback(const data::GpioAnalogDataView& data) override {
+    void gpio_analog_data_deserialized_callback(
+        uint8_t channel_index, const data::GpioAnalogDataView& data) override {
+        (void)channel_index;
         (void)data;
     }
 
     void gpio_digital_read_config_deserialized_callback(
-        const data::GpioReadConfigView& data) override {
+        uint8_t channel_index, const data::GpioReadConfigView& data) override {
+        (void)channel_index;
         (void)data;
     }
 
     void gpio_analog_read_config_deserialized_callback(
-        const data::GpioReadConfigView& data) override {
+        uint8_t channel_index, const data::GpioReadConfigView& data) override {
+        (void)channel_index;
         (void)data;
     }
 

--- a/firmware/rmcs_board/boards/lite/app/board_app.cpp
+++ b/firmware/rmcs_board/boards/lite/app/board_app.cpp
@@ -5,6 +5,7 @@
 #include <hpm_clock_drv.h>
 #include <hpm_common.h>
 #include <hpm_gpio_drv.h>
+#include <hpm_gpio_regs.h>
 #include <hpm_ioc_regs.h>
 #include <hpm_iomux.h>
 #include <hpm_mcan_regs.h>
@@ -136,6 +137,11 @@ uint32_t init_spi(SPI_Type* ptr) {
     return init_spi_clock(ptr);
 }
 
+void init_gpio_pins() {
+    kGpioHardwareDescriptors[0].configure_pioc_function();
+    kGpioHardwareDescriptors[1].configure_pioc_function();
+}
+
 void init_user_button_and_switch_pins() {
     kUserHsFsSwitchPin.configure_controller();
     kUserHsFsSwitchPin.configure_ioc_function();
@@ -155,7 +161,11 @@ void gpio_bmi088_int_isr() {
     if (kBmi088AccelIntPin.check_clear_interrupt_flag()) {
         bmi088_accel_dataready_irq_handler();
     }
+    gpio_irq_handler(GPIO_DI_GPIOB);
 }
+
+SDK_DECLARE_EXT_ISR_M(IRQn_GPIO0_Y, gpio_y_isr)
+void gpio_y_isr() { gpio_irq_handler(GPIO_DI_GPIOY); }
 
 SDK_DECLARE_EXT_ISR_M(BOARD_CAN0(IRQn_MCAN, ), can0_isr)
 void can0_isr() { can_irq_handler(0); }

--- a/firmware/rmcs_board/boards/lite/app/board_app.hpp
+++ b/firmware/rmcs_board/boards/lite/app/board_app.hpp
@@ -2,18 +2,24 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 
 #include <hpm_common.h>
 #include <hpm_gpiom_soc_drv.h>
+#include <hpm_iomux.h>
 #include <hpm_mcan_regs.h>
 #include <hpm_soc.h>
 #include <hpm_soc_irq.h>
 #include <hpm_spi_regs.h>
 #include <hpm_uart_regs.h>
 
+#include "core/include/librmcs/spec/rmcs_board_lite/gpio.hpp" // IWYU pragma: export
+#include "firmware/rmcs_board/app/src/gpio/analog_gpio_pin.hpp"
 #include "firmware/rmcs_board/app/src/gpio/gpio_pin.hpp"
 
 namespace librmcs::firmware::board {
+
+namespace spec = librmcs::spec::rmcs_board_lite; // NOLINT(misc-unused-alias-decls)
 
 #define BOARD_CAN0(prefix, suffix) prefix##1##suffix
 #define BOARD_CAN1(prefix, suffix) prefix##0##suffix
@@ -47,5 +53,16 @@ void bmi088_accel_dataready_irq_handler();
 constexpr GpioPin kUserHsFsSwitchPin = make_gpio_pin<gpiom_soc_gpio0, 'A', 31, false>();
 
 void init_user_button_and_switch_pins();
+
+inline constexpr AnalogGpioPin kGpioHardwareDescriptors[]{
+    make_gpio_pin<gpiom_soc_gpio0, 'Y', 1>(),
+    make_gpio_pin<gpiom_soc_gpio0, 'Y', 0>(),
+    make_gpio_pin<gpiom_soc_gpio0, 'B', 9>(),
+    make_gpio_pin<gpiom_soc_gpio0, 'B', 8>(),
+};
+static_assert(board::spec::kGpioDescriptors.size() == std::size(board::kGpioHardwareDescriptors));
+
+void init_gpio_pins();
+void gpio_irq_handler(uint32_t port_index);
 
 } // namespace librmcs::firmware::board

--- a/firmware/rmcs_board/boards/pro/app/board_app.cpp
+++ b/firmware/rmcs_board/boards/pro/app/board_app.cpp
@@ -5,6 +5,7 @@
 #include <hpm_clock_drv.h>
 #include <hpm_common.h>
 #include <hpm_gpio_drv.h>
+#include <hpm_gpio_regs.h>
 #include <hpm_ioc_regs.h>
 #include <hpm_iomux.h>
 #include <hpm_mcan_regs.h>
@@ -201,11 +202,19 @@ void init_user_button_and_switch_pins() {
     kUserHsFsSwitchPin.configure_as_input();
 }
 
+void init_gpio_pins() {
+    // Intentionally empty: No PIOC pins need to be configured.
+}
+
+SDK_DECLARE_EXT_ISR_M(IRQn_GPIO0_A, gpio_a_isr)
+void gpio_a_isr() { gpio_irq_handler(GPIO_DI_GPIOA); }
+
 SDK_DECLARE_EXT_ISR_M(IRQn_GPIO0_B, gpio_bmi088_int_gyro_isr)
 void gpio_bmi088_int_gyro_isr() {
     if (kBmi088GyroIntPin.check_clear_interrupt_flag()) {
         bmi088_gyro_dataready_irq_handler();
     }
+    gpio_irq_handler(GPIO_DI_GPIOB);
 }
 
 SDK_DECLARE_EXT_ISR_M(IRQn_GPIO0_Y, gpio_bmi088_int_accel_isr)
@@ -213,6 +222,7 @@ void gpio_bmi088_int_accel_isr() {
     if (kBmi088AccelIntPin.check_clear_interrupt_flag()) {
         bmi088_accel_dataready_irq_handler();
     }
+    gpio_irq_handler(GPIO_DI_GPIOY);
 }
 
 SDK_DECLARE_EXT_ISR_M(BOARD_CAN0(IRQn_MCAN, ), can0_isr)

--- a/firmware/rmcs_board/boards/pro/app/board_app.hpp
+++ b/firmware/rmcs_board/boards/pro/app/board_app.hpp
@@ -2,18 +2,24 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 
 #include <hpm_common.h>
 #include <hpm_gpiom_soc_drv.h>
+#include <hpm_iomux.h>
 #include <hpm_mcan_regs.h>
 #include <hpm_soc.h>
 #include <hpm_soc_irq.h>
 #include <hpm_spi_regs.h>
 #include <hpm_uart_regs.h>
 
+#include "core/include/librmcs/spec/rmcs_board_pro/gpio.hpp" // IWYU pragma: export
+#include "firmware/rmcs_board/app/src/gpio/analog_gpio_pin.hpp"
 #include "firmware/rmcs_board/app/src/gpio/gpio_pin.hpp"
 
 namespace librmcs::firmware::board {
+
+namespace spec = librmcs::spec::rmcs_board_pro;
 
 #define BOARD_CAN0(prefix, suffix) prefix##3##suffix
 #define BOARD_CAN1(prefix, suffix) prefix##2##suffix
@@ -50,5 +56,29 @@ constexpr GpioPin kUserButtonPin = make_gpio_pin<gpiom_soc_gpio0, 'Y', 3, false>
 constexpr GpioPin kUserHsFsSwitchPin = make_gpio_pin<gpiom_soc_gpio0, 'Y', 4, false>();
 
 void init_user_button_and_switch_pins();
+
+inline constexpr AnalogGpioPin kGpioHardwareDescriptors[]{
+    {make_gpio_pin<gpiom_soc_gpio0, 'B', 0>(), HPM_PWM0_BASE, IOC_PB00_FUNC_CTL_PWM0_P_0, 0},
+    {make_gpio_pin<gpiom_soc_gpio0, 'B', 1>(), HPM_PWM0_BASE, IOC_PB01_FUNC_CTL_PWM0_P_1, 1},
+    {make_gpio_pin<gpiom_soc_gpio0, 'B', 2>(), HPM_PWM0_BASE, IOC_PB02_FUNC_CTL_PWM0_P_2, 2},
+    {make_gpio_pin<gpiom_soc_gpio0, 'B', 3>(), HPM_PWM0_BASE, IOC_PB03_FUNC_CTL_PWM0_P_3, 3},
+    {make_gpio_pin<gpiom_soc_gpio0, 'A', 9>()},
+    {make_gpio_pin<gpiom_soc_gpio0, 'A', 10>()},
+    {make_gpio_pin<gpiom_soc_gpio0, 'A', 11>()},
+    {make_gpio_pin<gpiom_soc_gpio0, 'A', 12>()},
+    {make_gpio_pin<gpiom_soc_gpio0, 'A', 13>()},
+    {make_gpio_pin<gpiom_soc_gpio0, 'A', 18>()},
+    {make_gpio_pin<gpiom_soc_gpio0, 'A', 19>()},
+    {make_gpio_pin<gpiom_soc_gpio0, 'A', 22>()},
+    {make_gpio_pin<gpiom_soc_gpio0, 'A', 23>()},
+    {make_gpio_pin<gpiom_soc_gpio0, 'A', 14>()},
+    {make_gpio_pin<gpiom_soc_gpio0, 'A', 15>()},
+    {make_gpio_pin<gpiom_soc_gpio0, 'A', 1>()},
+    {make_gpio_pin<gpiom_soc_gpio0, 'A', 0>()},
+};
+static_assert(board::spec::kGpioDescriptors.size() == std::size(board::kGpioHardwareDescriptors));
+
+void init_gpio_pins();
+void gpio_irq_handler(uint32_t port_index);
 
 } // namespace librmcs::firmware::board

--- a/firmware/rmcs_board/bootloader/CMakeLists.txt
+++ b/firmware/rmcs_board/bootloader/CMakeLists.txt
@@ -67,6 +67,7 @@ sdk_compile_definitions(-DUSB_HOST_MCU_CORE=HPM_CORE0)
 sdk_compile_definitions(-DLIBRMCS_BOOTLOADER_MODE_AUTO=${bootloader_mode_auto})
 
 sdk_inc("${CMAKE_CURRENT_SOURCE_DIR}/include")
+sdk_app_inc("${LIBRMCS_PROJECT_ROOT}/core/include")
 sdk_app_inc("${LIBRMCS_PROJECT_ROOT}")
 
 file(GLOB_RECURSE PROJECT_SOURCE CONFIGURE_DEPENDS

--- a/host/include/librmcs/agent/c_board.hpp
+++ b/host/include/librmcs/agent/c_board.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
+#include <cstdint>
 #include <stdexcept>
 #include <string_view>
 
 #include <librmcs/agent/common.hpp>
 #include <librmcs/data/datas.hpp>
 #include <librmcs/protocol/handler.hpp>
+#include <librmcs/spec/c_board/gpio.hpp>
+#include <librmcs/spec/gpio.hpp>
 
 namespace librmcs::agent {
 
@@ -46,23 +49,28 @@ public:
             return *this;
         }
 
-        PacketBuilder& gpio_digital_write(const librmcs::data::GpioDigitalDataView& data) {
-            if (data.channel < 1 || data.channel > 7 || !builder_.write_gpio_digital_data(data))
-                [[unlikely]]
+        PacketBuilder& gpio_digital_write(
+            const librmcs::spec::c_board::GpioDescriptor& gpio,
+            const librmcs::data::GpioDigitalDataView& data) {
+            if (!gpio.supports(spec::GpioCapability::kDigitalWrite)
+                || !builder_.write_gpio_digital_data(gpio.channel_index, data)) [[unlikely]]
                 throw std::invalid_argument{"GPIO digital transmission failed: Invalid GPIO data"};
             return *this;
         }
-        PacketBuilder& gpio_digital_read(const librmcs::data::GpioReadConfigView& data) {
-            if (data.channel < 1 || data.channel > 7
-                || (data.channel == 6 && (data.rising_edge || data.falling_edge))
-                || !builder_.write_gpio_digital_read_config(data)) [[unlikely]]
+        PacketBuilder& gpio_digital_read(
+            const librmcs::spec::c_board::GpioDescriptor& gpio,
+            const librmcs::data::GpioReadConfigView& data) {
+            if (!data.supported(gpio)
+                || !builder_.write_gpio_digital_read_config(gpio.channel_index, data)) [[unlikely]]
                 throw std::invalid_argument{
                     "GPIO digital read configuration transmission failed: Invalid GPIO data"};
             return *this;
         }
-        PacketBuilder& gpio_analog_write(const librmcs::data::GpioAnalogDataView& data) {
-            if (data.channel < 1 || data.channel > 7 || !builder_.write_gpio_analog_data(data))
-                [[unlikely]]
+        PacketBuilder& gpio_analog_write(
+            const librmcs::spec::c_board::GpioDescriptor& gpio,
+            const librmcs::data::GpioAnalogDataView& data) {
+            if (!gpio.supports(spec::GpioCapability::kAnalogWrite)
+                || !builder_.write_gpio_analog_data(gpio.channel_index, data)) [[unlikely]]
                 throw std::invalid_argument{"GPIO analog transmission failed: Invalid GPIO data"};
             return *this;
         }
@@ -100,12 +108,30 @@ private:
     virtual void uart1_receive_callback(const librmcs::data::UartDataView& data) { (void)data; }
     virtual void uart2_receive_callback(const librmcs::data::UartDataView& data) { (void)data; }
 
-    void
-        gpio_digital_read_result_callback(const librmcs::data::GpioDigitalDataView& data) override {
+    virtual void gpio_digital_read_result_callback(
+        const librmcs::spec::c_board::GpioDescriptor& gpio,
+        const librmcs::data::GpioDigitalDataView& data) {
+        (void)gpio;
         (void)data;
     }
-    void gpio_analog_read_result_callback(const librmcs::data::GpioAnalogDataView& data) override {
+    virtual void gpio_analog_read_result_callback(
+        const librmcs::spec::c_board::GpioDescriptor& gpio,
+        const librmcs::data::GpioAnalogDataView& data) {
+        (void)gpio;
         (void)data;
+    }
+
+    void gpio_digital_read_result_callback(
+        uint8_t channel_index, const librmcs::data::GpioDigitalDataView& data) override {
+        if (channel_index >= spec::c_board::kGpioDescriptors.size()) [[unlikely]]
+            return;
+        gpio_digital_read_result_callback(spec::c_board::kGpioDescriptors[channel_index], data);
+    }
+    void gpio_analog_read_result_callback(
+        uint8_t channel_index, const librmcs::data::GpioAnalogDataView& data) override {
+        if (channel_index >= spec::c_board::kGpioDescriptors.size()) [[unlikely]]
+            return;
+        gpio_analog_read_result_callback(spec::c_board::kGpioDescriptors[channel_index], data);
     }
 
     void accelerometer_receive_callback(const librmcs::data::AccelerometerDataView& data) override {

--- a/host/include/librmcs/agent/rmcs_board_lite.hpp
+++ b/host/include/librmcs/agent/rmcs_board_lite.hpp
@@ -7,6 +7,8 @@
 #include <librmcs/agent/common.hpp>
 #include <librmcs/data/datas.hpp>
 #include <librmcs/protocol/handler.hpp>
+#include <librmcs/spec/gpio.hpp>
+#include <librmcs/spec/rmcs_board_lite/gpio.hpp>
 
 namespace librmcs::agent {
 
@@ -57,6 +59,32 @@ public:
             return *this;
         }
 
+        PacketBuilder& gpio_digital_write(
+            const librmcs::spec::rmcs_board_lite::GpioDescriptor& gpio,
+            const librmcs::data::GpioDigitalDataView& data) {
+            if (!gpio.supports(spec::GpioCapability::kDigitalWrite)
+                || !builder_.write_gpio_digital_data(gpio.channel_index, data)) [[unlikely]]
+                throw std::invalid_argument{"GPIO digital transmission failed: Invalid GPIO data"};
+            return *this;
+        }
+        PacketBuilder& gpio_digital_read(
+            const librmcs::spec::rmcs_board_lite::GpioDescriptor& gpio,
+            const librmcs::data::GpioReadConfigView& data) {
+            if (!data.supported(gpio)
+                || !builder_.write_gpio_digital_read_config(gpio.channel_index, data)) [[unlikely]]
+                throw std::invalid_argument{
+                    "GPIO digital read configuration transmission failed: Invalid GPIO data"};
+            return *this;
+        }
+        PacketBuilder& gpio_analog_write(
+            const librmcs::spec::rmcs_board_lite::GpioDescriptor& gpio,
+            const librmcs::data::GpioAnalogDataView& data) {
+            if (!gpio.supports(spec::GpioCapability::kAnalogWrite)
+                || !builder_.write_gpio_analog_data(gpio.channel_index, data)) [[unlikely]]
+                throw std::invalid_argument{"GPIO analog transmission failed: Invalid GPIO data"};
+            return *this;
+        }
+
     private:
         explicit PacketBuilder(host::protocol::Handler& handler) noexcept
             : builder_(handler.start_transmit()) {}
@@ -94,15 +122,32 @@ private:
     virtual void uart0_receive_callback(const librmcs::data::UartDataView& data) { (void)data; }
     virtual void uart1_receive_callback(const librmcs::data::UartDataView& data) { (void)data; }
 
-    void gpio_digital_read_result_callback(
-        uint8_t channel_index, const librmcs::data::GpioDigitalDataView& data) override {
-        (void)channel_index;
+    virtual void gpio_digital_read_result_callback(
+        const librmcs::spec::rmcs_board_lite::GpioDescriptor& gpio,
+        const librmcs::data::GpioDigitalDataView& data) {
+        (void)gpio;
         (void)data;
     }
-    void gpio_analog_read_result_callback(
-        uint8_t channel_index, const librmcs::data::GpioAnalogDataView& data) override {
-        (void)channel_index;
+    virtual void gpio_analog_read_result_callback(
+        const librmcs::spec::rmcs_board_lite::GpioDescriptor& gpio,
+        const librmcs::data::GpioAnalogDataView& data) {
+        (void)gpio;
         (void)data;
+    }
+
+    void gpio_digital_read_result_callback(
+        uint8_t channel_index, const librmcs::data::GpioDigitalDataView& data) final {
+        if (channel_index >= spec::rmcs_board_lite::kGpioDescriptors.size()) [[unlikely]]
+            return;
+        gpio_digital_read_result_callback(
+            spec::rmcs_board_lite::kGpioDescriptors[channel_index], data);
+    }
+    void gpio_analog_read_result_callback(
+        uint8_t channel_index, const librmcs::data::GpioAnalogDataView& data) final {
+        if (channel_index >= spec::rmcs_board_lite::kGpioDescriptors.size()) [[unlikely]]
+            return;
+        gpio_analog_read_result_callback(
+            spec::rmcs_board_lite::kGpioDescriptors[channel_index], data);
     }
 
     void accelerometer_receive_callback(const librmcs::data::AccelerometerDataView& data) override {

--- a/host/include/librmcs/agent/rmcs_board_lite.hpp
+++ b/host/include/librmcs/agent/rmcs_board_lite.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <stdexcept>
 #include <string_view>
 
@@ -93,11 +94,14 @@ private:
     virtual void uart0_receive_callback(const librmcs::data::UartDataView& data) { (void)data; }
     virtual void uart1_receive_callback(const librmcs::data::UartDataView& data) { (void)data; }
 
-    void
-        gpio_digital_read_result_callback(const librmcs::data::GpioDigitalDataView& data) override {
+    void gpio_digital_read_result_callback(
+        uint8_t channel_index, const librmcs::data::GpioDigitalDataView& data) override {
+        (void)channel_index;
         (void)data;
     }
-    void gpio_analog_read_result_callback(const librmcs::data::GpioAnalogDataView& data) override {
+    void gpio_analog_read_result_callback(
+        uint8_t channel_index, const librmcs::data::GpioAnalogDataView& data) override {
+        (void)channel_index;
         (void)data;
     }
 

--- a/host/include/librmcs/agent/rmcs_board_pro.hpp
+++ b/host/include/librmcs/agent/rmcs_board_pro.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <stdexcept>
 #include <string_view>
 
@@ -107,11 +108,14 @@ private:
     virtual void uart2_receive_callback(const librmcs::data::UartDataView& data) { (void)data; }
     virtual void uart3_receive_callback(const librmcs::data::UartDataView& data) { (void)data; }
 
-    void
-        gpio_digital_read_result_callback(const librmcs::data::GpioDigitalDataView& data) override {
+    void gpio_digital_read_result_callback(
+        uint8_t channel_index, const librmcs::data::GpioDigitalDataView& data) override {
+        (void)channel_index;
         (void)data;
     }
-    void gpio_analog_read_result_callback(const librmcs::data::GpioAnalogDataView& data) override {
+    void gpio_analog_read_result_callback(
+        uint8_t channel_index, const librmcs::data::GpioAnalogDataView& data) override {
+        (void)channel_index;
         (void)data;
     }
 

--- a/host/include/librmcs/agent/rmcs_board_pro.hpp
+++ b/host/include/librmcs/agent/rmcs_board_pro.hpp
@@ -7,6 +7,8 @@
 #include <librmcs/agent/common.hpp>
 #include <librmcs/data/datas.hpp>
 #include <librmcs/protocol/handler.hpp>
+#include <librmcs/spec/gpio.hpp>
+#include <librmcs/spec/rmcs_board_pro/gpio.hpp>
 
 namespace librmcs::agent {
 
@@ -67,6 +69,32 @@ public:
             return *this;
         }
 
+        PacketBuilder& gpio_digital_write(
+            const librmcs::spec::rmcs_board_pro::GpioDescriptor& gpio,
+            const librmcs::data::GpioDigitalDataView& data) {
+            if (!gpio.supports(spec::GpioCapability::kDigitalWrite)
+                || !builder_.write_gpio_digital_data(gpio.channel_index, data)) [[unlikely]]
+                throw std::invalid_argument{"GPIO digital transmission failed: Invalid GPIO data"};
+            return *this;
+        }
+        PacketBuilder& gpio_digital_read(
+            const librmcs::spec::rmcs_board_pro::GpioDescriptor& gpio,
+            const librmcs::data::GpioReadConfigView& data) {
+            if (!data.supported(gpio)
+                || !builder_.write_gpio_digital_read_config(gpio.channel_index, data)) [[unlikely]]
+                throw std::invalid_argument{
+                    "GPIO digital read configuration transmission failed: Invalid GPIO data"};
+            return *this;
+        }
+        PacketBuilder& gpio_analog_write(
+            const librmcs::spec::rmcs_board_pro::GpioDescriptor& gpio,
+            const librmcs::data::GpioAnalogDataView& data) {
+            if (!gpio.supports(spec::GpioCapability::kAnalogWrite)
+                || !builder_.write_gpio_analog_data(gpio.channel_index, data)) [[unlikely]]
+                throw std::invalid_argument{"GPIO analog transmission failed: Invalid GPIO data"};
+            return *this;
+        }
+
     private:
         explicit PacketBuilder(host::protocol::Handler& handler) noexcept
             : builder_(handler.start_transmit()) {}
@@ -109,13 +137,30 @@ private:
     virtual void uart3_receive_callback(const librmcs::data::UartDataView& data) { (void)data; }
 
     void gpio_digital_read_result_callback(
-        uint8_t channel_index, const librmcs::data::GpioDigitalDataView& data) override {
-        (void)channel_index;
-        (void)data;
+        uint8_t channel_index, const librmcs::data::GpioDigitalDataView& data) final {
+        if (channel_index >= spec::rmcs_board_pro::kGpioDescriptors.size()) [[unlikely]]
+            return;
+        gpio_digital_read_result_callback(
+            spec::rmcs_board_pro::kGpioDescriptors[channel_index], data);
     }
     void gpio_analog_read_result_callback(
-        uint8_t channel_index, const librmcs::data::GpioAnalogDataView& data) override {
-        (void)channel_index;
+        uint8_t channel_index, const librmcs::data::GpioAnalogDataView& data) final {
+        if (channel_index >= spec::rmcs_board_pro::kGpioDescriptors.size()) [[unlikely]]
+            return;
+        gpio_analog_read_result_callback(
+            spec::rmcs_board_pro::kGpioDescriptors[channel_index], data);
+    }
+
+    virtual void gpio_digital_read_result_callback(
+        const librmcs::spec::rmcs_board_pro::GpioDescriptor& gpio,
+        const librmcs::data::GpioDigitalDataView& data) {
+        (void)gpio;
+        (void)data;
+    }
+    virtual void gpio_analog_read_result_callback(
+        const librmcs::spec::rmcs_board_pro::GpioDescriptor& gpio,
+        const librmcs::data::GpioAnalogDataView& data) {
+        (void)gpio;
         (void)data;
     }
 

--- a/host/include/librmcs/protocol/handler.hpp
+++ b/host/include/librmcs/protocol/handler.hpp
@@ -24,11 +24,14 @@ public:
 
         bool write_uart(data::DataId field_id, const data::UartDataView& view) noexcept;
 
-        bool write_gpio_digital_data(const data::GpioDigitalDataView& view) noexcept;
+        bool write_gpio_digital_data(
+            uint8_t channel_index, const data::GpioDigitalDataView& view) noexcept;
 
-        bool write_gpio_digital_read_config(const data::GpioReadConfigView& view) noexcept;
+        bool write_gpio_digital_read_config(
+            uint8_t channel_index, const data::GpioReadConfigView& view) noexcept;
 
-        bool write_gpio_analog_data(const data::GpioAnalogDataView& view) noexcept;
+        bool write_gpio_analog_data(
+            uint8_t channel_index, const data::GpioAnalogDataView& view) noexcept;
 
         bool write_imu_accelerometer(const data::AccelerometerDataView& view) noexcept;
 

--- a/host/src/protocol/handler.cpp
+++ b/host/src/protocol/handler.cpp
@@ -48,22 +48,26 @@ public:
             logging::get_logger().error("Unexpected uart field id: ", static_cast<int>(id));
     }
 
-    void gpio_digital_data_deserialized_callback(const data::GpioDigitalDataView& data) override {
-        callback_.gpio_digital_read_result_callback(data);
+    void gpio_digital_data_deserialized_callback(
+        uint8_t channel_index, const data::GpioDigitalDataView& data) override {
+        callback_.gpio_digital_read_result_callback(channel_index, data);
     }
 
-    void gpio_analog_data_deserialized_callback(const data::GpioAnalogDataView& data) override {
-        callback_.gpio_analog_read_result_callback(data);
+    void gpio_analog_data_deserialized_callback(
+        uint8_t channel_index, const data::GpioAnalogDataView& data) override {
+        callback_.gpio_analog_read_result_callback(channel_index, data);
     }
 
     void gpio_digital_read_config_deserialized_callback(
-        const data::GpioReadConfigView& data) override {
+        uint8_t channel_index, const data::GpioReadConfigView& data) override {
+        (void)channel_index;
         (void)data;
         logging::get_logger().error("Unexpected gpio digital read config field in uplink");
     }
 
     void gpio_analog_read_config_deserialized_callback(
-        const data::GpioReadConfigView& data) override {
+        uint8_t channel_index, const data::GpioReadConfigView& data) override {
+        (void)channel_index;
         (void)data;
         logging::get_logger().error("Unexpected gpio analog read config field in uplink");
     }
@@ -113,17 +117,19 @@ struct PacketBuilderImpl {
         return process_result(serializer_.write_uart(field_id, view));
     }
 
-    [[nodiscard]] bool write_gpio_digital_data(const data::GpioDigitalDataView& view) noexcept {
-        return process_result(serializer_.write_gpio_digital_data(view));
+    [[nodiscard]] bool write_gpio_digital_data(
+        uint8_t channel_index, const data::GpioDigitalDataView& view) noexcept {
+        return process_result(serializer_.write_gpio_digital_data(channel_index, view));
     }
 
-    [[nodiscard]] bool
-        write_gpio_digital_read_config(const data::GpioReadConfigView& view) noexcept {
-        return process_result(serializer_.write_gpio_digital_read_config(view));
+    [[nodiscard]] bool write_gpio_digital_read_config(
+        uint8_t channel_index, const data::GpioReadConfigView& view) noexcept {
+        return process_result(serializer_.write_gpio_digital_read_config(channel_index, view));
     }
 
-    [[nodiscard]] bool write_gpio_analog_data(const data::GpioAnalogDataView& view) noexcept {
-        return process_result(serializer_.write_gpio_analog_data(view));
+    [[nodiscard]] bool write_gpio_analog_data(
+        uint8_t channel_index, const data::GpioAnalogDataView& view) noexcept {
+        return process_result(serializer_.write_gpio_analog_data(channel_index, view));
     }
 
     [[nodiscard]] bool write_imu_accelerometer(const data::AccelerometerDataView& view) noexcept {
@@ -178,20 +184,21 @@ bool Handler::PacketBuilder::write_uart(
 }
 
 bool Handler::PacketBuilder::write_gpio_digital_data(
-    const data::GpioDigitalDataView& view) noexcept {
+    uint8_t channel_index, const data::GpioDigitalDataView& view) noexcept {
     return std::launder(reinterpret_cast<PacketBuilderImpl*>(storage_))
-        ->write_gpio_digital_data(view);
+        ->write_gpio_digital_data(channel_index, view);
 }
 
 bool Handler::PacketBuilder::write_gpio_digital_read_config(
-    const data::GpioReadConfigView& view) noexcept {
+    uint8_t channel_index, const data::GpioReadConfigView& view) noexcept {
     return std::launder(reinterpret_cast<PacketBuilderImpl*>(storage_))
-        ->write_gpio_digital_read_config(view);
+        ->write_gpio_digital_read_config(channel_index, view);
 }
 
-bool Handler::PacketBuilder::write_gpio_analog_data(const data::GpioAnalogDataView& view) noexcept {
+bool Handler::PacketBuilder::write_gpio_analog_data(
+    uint8_t channel_index, const data::GpioAnalogDataView& view) noexcept {
     return std::launder(reinterpret_cast<PacketBuilderImpl*>(storage_))
-        ->write_gpio_analog_data(view);
+        ->write_gpio_analog_data(channel_index, view);
 }
 
 bool Handler::PacketBuilder::write_imu_accelerometer(


### PR DESCRIPTION
## feat(gpio)!: Add descriptor-based GPIO capability model

- Extract channel field from GPIO data views (GpioDigitalDataView, GpioAnalogDataView, GpioReadConfigView) into an explicit channel_index parameter threaded through serialization, deserialization, and callbacks.
- Introduce GpioCapability bitmask enum and GpioDescriptor in core/spec, with c_board-specific descriptors that declare per-channel capabilities (e.g. channel 5 lacks interrupt support).
- Add GpioReadConfigView::supported() for unified host/firmware validation of read configurations against descriptor capabilities.
- Replace hardcoded channel-6 EXTI exclusion in c_board firmware with declarative capability mask in the shared descriptor table.
- Rename wire-protocol field GpioHeader::Channel to ChannelIndex and switch c_board channel numbering from 1-based to 0-based.
- Update c_board host agent API to accept GpioDescriptor references instead of raw channel numbers.
- Add core/include to firmware build targets that consume shared specs.

BREAKING CHANGE: GPIO data views no longer carry a channel field; all GPIO protocol and callback APIs now take a zero-based channel_index. c_board host agent methods require a GpioDescriptor reference instead of a raw channel number.

## feat(gpio)!: Add GPIO support for rmcs_board and align input sampling semantics

- Add board-specific GPIO descriptors and host-side typed GPIO APIs for rmcs_board lite and pro.
- Implement rmcs_board firmware GPIO handling for digital input, digital output, interrupt-driven input reporting, and PWM output on supported pro channels.
- Refactor c_board digital input scheduling to use deadline-based periodic sampling. This changes the sampling behavior for read configurations with period_ms > 0.

BREAKING CHANGE: Digital GPIO read configurations with period_ms > 0 now emit the first periodic sample on the next polling cycle instead of waiting for a full period to elapse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# GPIO 描述符模型重构（更新）

## 概览
本 PR 将 GPIO 支持从多处硬编码与 1-based 通道编号迁移为声明式的描述符驱动模型，统一使用零基 channel_index。改动横跨 core 协议、共享 spec、主机代理与固件（c_board、rmcs_board 及板级变体），引入能力位掩码、板级描述符表、协议字段/签名变更，并重构固件 GPIO 子系统以按描述符驱动行为与能力检查。

## 主要变更点

1. 协议与数据视图
- 移除 GpioDigitalDataView、GpioAnalogDataView、GpioReadConfigView 中的 channel 字段，序列化/反序列化与回调统一通过显式 uint8_t channel_index 传递。
- GpioHeader 的位域别名由 Channel 重命名为 ChannelIndex（位宽不变）。
- Serializer/Deserializer 的所有 GPIO 读写/结果/配置方法改为接受 channel_index，并在写入时断言位宽。

2. 能力位与描述符
- 新增 librmcs::spec::GpioCapability（按位枚举）及相应位运算重载，表示 digital/analog write、digital read（一次/周期/中断）、pull-up/down 等能力。
- 新增通用 spec::GpioDescriptor（channel_index + capability_mask + supports()），并提供 consteval 的 channel_indices_match_indices 辅助用于编译期一致性校验。

3. 板级描述符表
- 为 c_board、rmcs_board_lite、rmcs_board_pro 等添加板级描述符类型与 kGpioDescriptors 常量数组（例如 c_board 通道 0–6，channel 5 去除中断能力以取代此前 channel6 的固件特例）。
- 描述符类型为不可拷贝/不可移动的派生包装，提供命名别名（如 kPwm1..kPwm7）与 constexpr 访问器。

4. 读配置校验
- 新增 GpioReadConfigView::supported(const spec::GpioDescriptor&)，主机与固件均使用它基于描述符能力校验读配置（asap、period_ms、边沿触发、pull 等）。

5. 固件重构与功能
- 固件统一使用 0-based 通道索引；移除 1-based 编号逻辑。
- 引入 AnalogGpioPin、板级硬件描述符数组（kGpioHardwareDescriptors），并在板初始化中设置 IOC/复用。
- 新增并实现 firmware::gpio::Gpio 子系统：数字输出、PWM（模拟输出）、数字输入、基于 deadline 的周期采样调度、以及中断驱动的输入上报。c_board 固件将 EXTI 特例替换为描述符能力控制与 exti->channel_index 映射。
- poll/调度重构：数字输入的周期采样改为 deadline/下次截止时间调度；period_ms > 0 的读配置现在在下一轮轮询周期（而非等待完整周期）首次产生周期样本（破坏性语义变更）。
- 在固件中添加 init_gpio_pins() 与 gpio_irq_handler 等挂钩；若干板 ISR 更新为调用通用 gpio_irq_handler。

6. 主机端与 Agent API
- CBoard / RmcsBoardLite / RmcsBoardPro 等 PacketBuilder 的 GPIO 发送接口改为接受 const GpioDescriptor&（而非原始通道号）；发送前基于描述符能力校验并使用 gpio.channel_index 调用底层序列化器。
- 读取结果回调链改为序列化层先提供 uint8_t channel_index，agent/host 层边界检查后将对应描述符转发至新的虚拟回调（descriptor + data view）；保留最终可覆盖点供用户处理特定描述符。
- host 协议 Handler 的 PacketBuilder 写入方法签名改为 (uint8_t channel_index, const View&)，并在内部传入 serializer。

7. 构建与包含路径
- 将 core/include 添加到固件（c_board、rmcs_board bootloader/app）与固件目标的 include 路径，以便固件/主机消费共享的 spec 头文件。

8. 其它调整
- c_board 主机代理方法从接收原始通道号变更为接收 GpioDescriptor 引用（破坏性）。
- DataCallback / DeserializeCallback 等回调签名已相应更新以包含 channel_index。
- timer::kMaxDurationTicks 类型由 uint64_t 改为 uint32_t 并新增 check_reached 辅助。
- 添加 AnalogGpioPin 与 PWM 支持工具函数与断言。

## 破坏性变更（需注意）
- GPIO 数据视图不再包含 channel 字段；所有相关 API/回调现在以零基 channel_index 作为独立参数。
- 各板主机代理与 PacketBuilder 写接口改为接受 GpioDescriptor 引用或显式 channel_index，调用方必须使用 spec::...::kGpioDescriptors 或保存描述符引用。
- 数字读配置的初始周期采样时序变更（period_ms > 0 时首次周期样本在下一轮轮询产生，而不再等待完整周期）。
- 需更新所有以 1-based 传递通道的用户代码为 0-based 或改为使用描述符的 channel_index。

## 迁移建议
- 将所有调用改为传递零基 channel_index，或改为传入板级 kGpioDescriptors 中的 GpioDescriptor 引用并依赖库在内部使用 gpio.channel_index。
- 主机侧在调用 PacketBuilder 前应基于 GpioDescriptor 做能力校验，或依赖 PacketBuilder 已做的校验。
- 固件板级初始化需调用新增 init_gpio_pins() 并确保 kGpioHardwareDescriptors 与 spec 描述符数组长度一致（已有 static_assert 校验）。

## 审查重点
- 描述符表与硬件描述符的索引/顺序一致性（channel_indices_match_indices 与 static_assert）。
- GpioCapability 定义及组合语义（中断/周期/一次性读等能力互斥与兼容性）。
- Serializer/Deserializer 对 GpioHeader 位宽与 channel_index 断言的一致性。
- 固件 PWM 初始化与多通道共享资源（reload/clock）实现的正确性与鲁棒性。
- 主机端 API 迁移路径与异常/错误处理逻辑。

总体而言，本 PR 用描述符与能力模型替换了多处板级特例并统一了通道索引语义，提升可扩展性与表达能力，但伴随较多接口变更与迁移工作。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->