### PR TITLE
feat(firmware/rmcs_board): Add WS2812 status LED feedback

### DIFF
--- a/firmware/c_board/app/src/utility/lazy.hpp
+++ b/firmware/c_board/app/src/utility/lazy.hpp
@@ -11,6 +11,8 @@
 
 namespace librmcs::firmware::utility {
 
+// Lazy-initialized object with deferred construction.
+// Thread-safe single-time initialization guarded by interrupt lock.
 template <typename T, typename... Args>
 class Lazy {
 public:
@@ -25,6 +27,11 @@ public:
 
     constexpr ~Lazy() {} // No need to deconstruct
 
+    /*!
+     * @brief Construct the object on first call; no-op on subsequent calls.
+     * @return Reference to the constructed object
+     * @note Thread-safe. Uses interrupt lock for atomic state transitions.
+     */
     constexpr T& init() {
         const InterruptLockGuard guard;
 
@@ -44,16 +51,46 @@ public:
         return object_;
     }
 
+    /*!
+     * @brief Get pointer to the constructed object, or nullptr if not yet
+     *        initialized.
+     * @return Pointer to the object, or nullptr if not yet initialized
+     * @note Does not assert on uninitialized state. Check return before use.
+     */
+    constexpr T* try_get() {
+        if (!static_cast<bool>(*this))
+            return nullptr;
+        return std::addressof(object_);
+    }
+
+    /*!
+     * @brief Get pointer to the constructed object
+     * @return Pointer to the constructed object
+     * @warning Must only be called after init(). Asserts if uninitialized
+     *          in debug builds.
+     */
     constexpr T* get() {
         core::utility::assert_debug(static_cast<bool>(*this));
         return std::addressof(object_);
     }
 
+    /*!
+     * @brief Member access through the constructed object
+     * @return Pointer to the constructed object
+     * @warning Must only be called after init(). Asserts if uninitialized
+     *          in debug builds.
+     */
     constexpr T* operator->() {
         core::utility::assert_debug(static_cast<bool>(*this));
         return std::addressof(object_);
     }
 
+    /*!
+     * @brief Dereference to access the constructed object
+     * @return Reference to the constructed object
+     * @warning Must only be called after init(). Asserts if uninitialized
+     *          in debug builds.
+     */
     constexpr T& operator*() {
         core::utility::assert_debug(static_cast<bool>(*this));
         return object_;

--- a/firmware/rmcs_board/app/src/app.cpp
+++ b/firmware/rmcs_board/app/src/app.cpp
@@ -6,8 +6,10 @@
 
 #include "firmware/rmcs_board/app/src/can/can.hpp"
 #include "firmware/rmcs_board/app/src/gpio/gpio.hpp"
+#include "firmware/rmcs_board/app/src/led/led.hpp"
 #include "firmware/rmcs_board/app/src/spi/bmi088/accel.hpp"
 #include "firmware/rmcs_board/app/src/spi/bmi088/gyro.hpp"
+#include "firmware/rmcs_board/app/src/timer/tick.hpp"
 #include "firmware/rmcs_board/app/src/uart/uart.hpp"
 #include "firmware/rmcs_board/app/src/usb/vendor.hpp"
 #include "firmware/rmcs_board/app/src/utility/boot_mailbox.hpp"
@@ -25,6 +27,8 @@ App::App() {
     dma_mgr_init();
     boot::BootMailbox::clear();
 
+    led::led.init();
+
     usb::vendor.init();
 
     for (auto& can : can::can_array)
@@ -38,6 +42,8 @@ App::App() {
 
     spi::bmi088::accelerometer.init();
     spi::bmi088::gyroscope.init();
+
+    timer::tick.init();
 }
 
 // Non-static to ensure instantiation

--- a/firmware/rmcs_board/app/src/can/can.hpp
+++ b/firmware/rmcs_board/app/src/can/can.hpp
@@ -18,6 +18,7 @@
 #include "core/src/protocol/serializer.hpp"
 #include "core/src/utility/assert.hpp"
 #include "core/src/utility/immovable.hpp"
+#include "firmware/rmcs_board/app/src/led/led.hpp"
 #include "firmware/rmcs_board/app/src/usb/helper.hpp"
 #include "firmware/rmcs_board/app/src/utility/lazy.hpp"
 
@@ -78,7 +79,9 @@ public:
         if (!data.can_data.empty())
             std::memcpy(frame.data_8, data.can_data.data(), data.can_data.size());
 
-        mcan_transmit_via_txfifo_nonblocking(can_base_, &frame, nullptr);
+        const hpm_stat_t status = mcan_transmit_via_txfifo_nonblocking(can_base_, &frame, nullptr);
+        if (status != status_success)
+            led::led->downlink_buffer_full();
     }
 
     void handle_uplink(core::protocol::FieldId field_id, core::protocol::Serializer& serializer) {

--- a/firmware/rmcs_board/app/src/gpio/analog_gpio_pin.hpp
+++ b/firmware/rmcs_board/app/src/gpio/analog_gpio_pin.hpp
@@ -30,7 +30,13 @@ public:
         core::utility::assert_debug(pwm_ioc_function < 32 && pwm_output_index < 8);
     }
 
-    [[nodiscard]] constexpr bool supports_pwm() const noexcept { return pwm_base_ != 0; }
+    constexpr uintptr_t pwm_base() const { return pwm_base_; }
+    constexpr uint32_t pwm_ioc_function() const { return pwm_ioc_function_; }
+    constexpr uint8_t pwm_output_index() const { return pwm_output_index_; }
+
+    PWM_Type* pwm_instance() const { return reinterpret_cast<PWM_Type*>(pwm_base_); }
+
+    [[nodiscard]] constexpr bool supports_pwm() const noexcept { return pwm_base() != 0; }
 
     void configure_as_gpio() const {
         configure_controller();
@@ -40,7 +46,7 @@ public:
     void configure_as_pwm() const {
         core::utility::assert_debug(supports_pwm());
         configure_controller();
-        configure_ioc_function(pwm_ioc_function_);
+        configure_ioc_function(pwm_ioc_function());
     }
 
     void disable_interrupt() const {
@@ -50,7 +56,7 @@ public:
 
     void update_pwm_compare_edge_aligned(uint32_t compare_value) const {
         core::utility::assert_debug(supports_pwm());
-        pwm_update_raw_cmp_edge_aligned(pwm_instance(), pwm_output_index_, compare_value);
+        pwm_update_raw_cmp_edge_aligned(pwm_instance(), pwm_output_index(), compare_value);
     }
 
     hpm_stat_t setup_pwm_waveform_edge_aligned(uint32_t reload, pwm_config_t& pwm_config) const {
@@ -61,12 +67,10 @@ public:
         cmp_config.cmp = reload + 1;
 
         return pwm_setup_waveform(
-            pwm_instance(), pwm_output_index_, &pwm_config, pwm_output_index_, &cmp_config, 1);
+            pwm_instance(), pwm_output_index(), &pwm_config, pwm_output_index(), &cmp_config, 1);
     }
 
 private:
-    PWM_Type* pwm_instance() const { return reinterpret_cast<PWM_Type*>(pwm_base_); }
-
     uintptr_t pwm_base_;
 
     uint8_t pwm_ioc_function_;

--- a/firmware/rmcs_board/app/src/led/led.hpp
+++ b/firmware/rmcs_board/app/src/led/led.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+#include "firmware/rmcs_board/app/src/led/ws2812.hpp"
+#include "firmware/rmcs_board/app/src/utility/lazy.hpp"
+
+namespace librmcs::firmware::led {
+
+class Led {
+public:
+    using Lazy = utility::Lazy<Led>;
+
+    Led() { ws2812.init(); }
+
+    void reset() {
+        uplink_full_reset_counter_.store(0, std::memory_order::relaxed);
+        downlink_full_reset_counter_.store(0, std::memory_order::relaxed);
+    }
+
+    void uplink_buffer_full() {
+        uplink_full_reset_counter_.store(5000, std::memory_order::relaxed);
+    }
+
+    void downlink_buffer_full() {
+        downlink_full_reset_counter_.store(5000, std::memory_order::relaxed);
+    }
+
+    void update(uint32_t tick) {
+        uint16_t uplink_full;
+        do {
+            uplink_full = uplink_full_reset_counter_.load(std::memory_order::relaxed);
+            if (uplink_full == 0)
+                break;
+        } while (!uplink_full_reset_counter_.compare_exchange_weak(
+            uplink_full, uplink_full - 1, std::memory_order::relaxed));
+
+        uint16_t downlink_full;
+        do {
+            downlink_full = downlink_full_reset_counter_.load(std::memory_order::relaxed);
+            if (downlink_full == 0)
+                break;
+        } while (!downlink_full_reset_counter_.compare_exchange_weak(
+            downlink_full, downlink_full - 1, std::memory_order::relaxed));
+
+        if (uplink_full && downlink_full) {
+            if (tick & 128U)
+                ws2812->set_value(255, 255, 0);
+            else
+                ws2812->set_value(0, 255, 255);
+        } else if (uplink_full) {
+            if (tick & 128U)
+                ws2812->set_value(255, 255, 0);
+            else
+                ws2812->set_value(0, 0, 0);
+        } else if (downlink_full) {
+            if (tick & 128U)
+                ws2812->set_value(0, 0, 0);
+            else
+                ws2812->set_value(0, 255, 255);
+        } else {
+            uint32_t brightness = (tick >> 2U) & 511U;
+            if (brightness > 255U)
+                brightness = 511U - brightness;
+            ws2812->set_value(0, static_cast<uint8_t>(brightness), 0);
+        }
+    }
+
+private:
+    std::atomic<uint16_t> uplink_full_reset_counter_{0};
+    std::atomic<uint16_t> downlink_full_reset_counter_{0};
+};
+
+inline constinit Led::Lazy led;
+
+} // namespace librmcs::firmware::led

--- a/firmware/rmcs_board/app/src/led/ws2812.hpp
+++ b/firmware/rmcs_board/app/src/led/ws2812.hpp
@@ -1,0 +1,159 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+#include <hpm_clock_drv.h>
+#include <hpm_common.h>
+#include <hpm_dma_mgr.h>
+#include <hpm_dmamux_src.h>
+#include <hpm_dmav2_drv.h>
+#include <hpm_dmav2_regs.h>
+#include <hpm_l1c_drv.h>
+#include <hpm_pwm_drv.h>
+#include <hpm_pwm_regs.h>
+#include <hpm_soc.h>
+#include <hpm_soc_feature.h>
+#include <hpm_trgm_drv.h>
+#include <hpm_trgm_regs.h>
+#include <hpm_trgmmux_src.h>
+
+#include "board_app.hpp"
+#include "core/src/utility/assert.hpp"
+#include "core/src/utility/immovable.hpp"
+#include "firmware/rmcs_board/app/src/gpio/analog_gpio_pin.hpp"
+#include "firmware/rmcs_board/app/src/utility/lazy.hpp"
+
+namespace librmcs::firmware::led {
+
+class Ws2812 : private core::utility::Immovable {
+public:
+    using Lazy = utility::Lazy<Ws2812>;
+
+    static constexpr size_t kWs2812BitCount = 24;
+    static constexpr uint32_t kWs2812PwmFrequencyHz = 800'000;
+
+    static_assert(board::kWs2812Pin.supports_pwm());
+    static_assert(board::kWs2812Pin.pwm_base() == HPM_PWM1_BASE);
+
+    explicit Ws2812() {
+        board::init_ws2812_pin();
+
+        clock_add_to_group(clock_mot0, 0);
+        const uint32_t pwm_clock_hz = clock_get_frequency(clock_mot0);
+        core::utility::assert_always(pwm_clock_hz >= kWs2812PwmFrequencyHz);
+
+        const uint32_t pwm_reload = pwm_clock_hz / kWs2812PwmFrequencyHz;
+        core::utility::assert_always(pwm_reload > 1);
+
+        compare_bit0_ = static_cast<uint32_t>(static_cast<uint64_t>(pwm_reload) * 8 / 25);
+        compare_bit1_ = static_cast<uint32_t>(static_cast<uint64_t>(pwm_reload) * 16 / 25);
+        compare_reset_ = pwm_reload;
+        compare_values_[0] = PWM_CMP_CMP_SET(compare_reset_);
+        compare_values_[kWs2812BitCount + 1] = PWM_CMP_CMP_SET(compare_reset_);
+
+        pwm_deinit(HPM_PWM1);
+        pwm_set_reload(HPM_PWM1, 0, pwm_reload);
+        pwm_set_start_count(HPM_PWM1, 0, 0);
+
+        pwm_config_t pwm_config{};
+        pwm_get_default_pwm_config(HPM_PWM1, &pwm_config);
+        pwm_config.enable_output = true;
+        pwm_config.invert_output = true;
+
+        pwm_cmp_config_t pwm_cmp_config{};
+        pwm_get_default_cmp_config(HPM_PWM1, &pwm_cmp_config);
+        pwm_cmp_config.cmp = compare_reset_;
+        pwm_cmp_config.update_trigger = pwm_shadow_register_update_on_modify;
+        pwm_config_cmp(HPM_PWM1, board::kWs2812Pin.pwm_output_index(), &pwm_cmp_config);
+
+        pwm_cmp_config.update_trigger = pwm_shadow_register_update_on_hw_event;
+        core::utility::assert_always(
+            pwm_setup_waveform(
+                HPM_PWM1, board::kWs2812Pin.pwm_output_index(), &pwm_config,
+                board::kWs2812Pin.pwm_output_index(), &pwm_cmp_config, 1)
+            == status_success);
+
+        pwm_cmp_config.cmp = pwm_reload - 1;
+        pwm_cmp_config.update_trigger = pwm_shadow_register_update_on_modify;
+        core::utility::assert_always(
+            pwm_load_cmp_shadow_on_match(HPM_PWM1, 8, &pwm_cmp_config) == status_success);
+
+        init_dma();
+
+        trgm_dma_request_config(HPM_TRGM0, TRGM_DMACFG_0, HPM_TRGM0_DMA_SRC_PWM1_HALFRLD);
+        pwm_enable_dma_request(HPM_PWM1, PWM_IRQ_HALF_RELOAD);
+
+        pwm_start_counter(HPM_PWM1);
+        pwm_issue_shadow_register_lock_event(HPM_PWM1);
+    }
+
+    bool set_value(uint8_t red, uint8_t green, uint8_t blue) {
+        // The LED is too bright; reduce the brightness.
+        red /= 8;
+        green /= 8;
+        blue /= 8;
+
+        if (dma_channel_is_enable(dma_resource_.base, dma_resource_.channel))
+            return false;
+
+        const uint32_t grb = (static_cast<uint32_t>(green) << 16)
+                           | (static_cast<uint32_t>(red) << 8) | static_cast<uint32_t>(blue);
+
+        for (size_t i = 0; i < kWs2812BitCount; i++) {
+            const bool is_one = (grb & (1UL << (kWs2812BitCount - 1 - i))) != 0;
+            compare_values_[i + 1] = PWM_CMP_CMP_SET(is_one ? compare_bit1_ : compare_bit0_);
+        }
+
+        l1c_dc_writeback(
+            reinterpret_cast<uintptr_t>(compare_values_.data()),
+            HPM_L1C_CACHELINE_ALIGN_UP(sizeof(compare_values_)));
+
+        auto& ctrl = dma_resource_.base->CHCTRL[dma_resource_.channel];
+        ctrl.SRCADDR = reinterpret_cast<uintptr_t>(compare_values_.data());
+        ctrl.TRANSIZE = compare_values_.size();
+        ctrl.CTRL |= DMAV2_CHCTRL_CTRL_ENABLE_MASK;
+
+        return true;
+    }
+
+private:
+    void init_dma() {
+        dma_mgr_chn_conf_t config;
+        dma_mgr_get_default_chn_config(&config);
+
+        config.en_dmamux = true;
+        config.dmamux_src = HPM_DMA_SRC_MOT_0;
+        config.priority = DMA_MGR_CHANNEL_PRIORITY_LOW;
+        config.src_addr = reinterpret_cast<uintptr_t>(compare_values_.data());
+        config.dst_addr =
+            reinterpret_cast<uintptr_t>(&HPM_PWM1->CMP[board::kWs2812Pin.pwm_output_index()]);
+        config.src_width = DMA_MGR_TRANSFER_WIDTH_WORD;
+        config.dst_width = DMA_MGR_TRANSFER_WIDTH_WORD;
+        config.src_addr_ctrl = DMA_MGR_ADDRESS_CONTROL_INCREMENT;
+        config.dst_addr_ctrl = DMA_MGR_ADDRESS_CONTROL_FIXED;
+        config.src_mode = DMA_MGR_HANDSHAKE_MODE_NORMAL;
+        config.dst_mode = DMA_MGR_HANDSHAKE_MODE_HANDSHAKE;
+        config.src_burst_size = DMA_MGR_NUM_TRANSFER_PER_BURST_1T;
+        config.size_in_byte = sizeof(compare_values_);
+        config.en_infiniteloop = false;
+        config.interrupt_mask = DMA_MGR_INTERRUPT_MASK_ALL;
+
+        core::utility::assert_always(
+            dma_mgr_request_specified_resource(&dma_resource_, HPM_HDMA) == status_success
+            && dma_mgr_setup_channel(&dma_resource_, &config) == status_success);
+    }
+
+    dma_resource_t dma_resource_{};
+
+    uint32_t compare_bit0_ = 0;
+    uint32_t compare_bit1_ = 0;
+    uint32_t compare_reset_ = 0;
+
+    alignas(HPM_L1C_CACHELINE_SIZE) std::array<uint32_t, 1 + kWs2812BitCount + 1> compare_values_;
+};
+
+inline constinit Ws2812::Lazy ws2812;
+
+} // namespace librmcs::firmware::led

--- a/firmware/rmcs_board/app/src/timer/tick.cpp
+++ b/firmware/rmcs_board/app/src/timer/tick.cpp
@@ -1,0 +1,9 @@
+#include "firmware/rmcs_board/app/src/timer/tick.hpp"
+
+#include "board_app.hpp"
+
+namespace librmcs::firmware::board {
+
+void tick_clock_irq_handler() { timer::tick->irq_handler(); }
+
+} // namespace librmcs::firmware::board

--- a/firmware/rmcs_board/app/src/timer/tick.hpp
+++ b/firmware/rmcs_board/app/src/timer/tick.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cstdint>
+
+#include <hpm_gptmr_drv.h>
+#include <hpm_soc.h>
+#include <hpm_soc_irq.h>
+
+#include "board_app.hpp"
+#include "firmware/rmcs_board/app/src/led/led.hpp"
+#include "firmware/rmcs_board/app/src/utility/lazy.hpp"
+
+namespace librmcs::firmware::timer {
+
+class Tick {
+public:
+    using Lazy = utility::Lazy<Tick>;
+
+    Tick() {
+        const uint32_t freq = board::init_tick_clock();
+
+        gptmr_channel_config_t config;
+        gptmr_channel_get_default_config(BOARD_TICK_CLOCK, &config);
+        config.reload = (freq + 500) / 1000U; // 1kHz
+        gptmr_channel_config(BOARD_TICK_CLOCK, 0, &config, false);
+
+        gptmr_enable_irq(BOARD_TICK_CLOCK, GPTMR_CH_RLD_IRQ_MASK(0));
+        intc_m_enable_irq_with_priority(IRQn_GPTMR1, 1);
+
+        gptmr_start_counter(BOARD_TICK_CLOCK, 0);
+    }
+
+    void irq_handler() {
+        if (gptmr_check_status(BOARD_TICK_CLOCK, GPTMR_CH_RLD_STAT_MASK(0))) {
+            gptmr_clear_status(BOARD_TICK_CLOCK, GPTMR_CH_RLD_STAT_MASK(0));
+            tick_counter_ = tick_counter_ + 1;
+            led::led->update(tick_counter_);
+        }
+    }
+
+private:
+    uint32_t tick_counter_ = 0;
+};
+
+inline constinit Tick::Lazy tick;
+
+} // namespace librmcs::firmware::timer

--- a/firmware/rmcs_board/app/src/uart/uart.hpp
+++ b/firmware/rmcs_board/app/src/uart/uart.hpp
@@ -16,6 +16,7 @@
 #include "core/src/protocol/serializer.hpp"
 #include "core/src/utility/assert.hpp"
 #include "core/src/utility/immovable.hpp"
+#include "firmware/rmcs_board/app/src/led/led.hpp"
 #include "firmware/rmcs_board/app/src/uart/rx_buffer.hpp"
 #include "firmware/rmcs_board/app/src/uart/tx_buffer.hpp"
 #include "firmware/rmcs_board/app/src/usb/helper.hpp"
@@ -49,7 +50,10 @@ public:
         init_uart(board_config.irq_num, baudrate, parity);
     }
 
-    void handle_downlink(const data::UartDataView& data) { TxBuffer::try_enqueue(data); }
+    void handle_downlink(const data::UartDataView& data) {
+        if (!TxBuffer::try_enqueue(data))
+            led::led->downlink_buffer_full();
+    }
 
     void try_transmit() { TxBuffer::try_dequeue(); }
 

--- a/firmware/rmcs_board/app/src/usb/interrupt_safe_buffer.hpp
+++ b/firmware/rmcs_board/app/src/usb/interrupt_safe_buffer.hpp
@@ -10,6 +10,7 @@
 #include "core/src/protocol/serializer.hpp"
 #include "core/src/utility/assert.hpp"
 #include "core/src/utility/immovable.hpp"
+#include "firmware/rmcs_board/app/src/led/led.hpp"
 
 namespace librmcs::firmware::usb {
 
@@ -42,7 +43,7 @@ public:
 
             auto writeable = kBatchCount - readable - 1;
             if (!writeable) {
-                // TODO: buffer full indication hook (LED/log); platform pending.
+                led::led->uplink_buffer_full();
                 return {};
             }
 

--- a/firmware/rmcs_board/app/src/utility/assert.cpp
+++ b/firmware/rmcs_board/app/src/utility/assert.cpp
@@ -21,10 +21,10 @@ const char* volatile assert_function = nullptr;
     assert_line = location.line();
     assert_function = location.function_name();
 
-    if (firmware::led::ws2812) {
+    if (auto* ws2812 = firmware::led::ws2812.try_get()) {
         for (int i = 0; i < 10; i++)
             board_delay_ms(10);
-        firmware::led::ws2812->set_value(255, 0, 0);
+        ws2812->set_value(255, 0, 0);
     }
 
     __builtin_trap();

--- a/firmware/rmcs_board/app/src/utility/assert.cpp
+++ b/firmware/rmcs_board/app/src/utility/assert.cpp
@@ -2,6 +2,12 @@
 
 #include <source_location>
 
+#include <board.h>
+#include <hpm_csr_regs.h>
+#include <hpm_soc.h>
+
+#include "firmware/rmcs_board/app/src/led/ws2812.hpp"
+
 namespace librmcs::core::utility {
 
 const char* volatile assert_file = nullptr;
@@ -9,9 +15,17 @@ volatile unsigned int assert_line = 0;
 const char* volatile assert_function = nullptr;
 
 [[noreturn]] void assert_func(const std::source_location& location) {
+    disable_global_irq(CSR_MSTATUS_MIE_MASK);
+
     assert_file = location.file_name();
     assert_line = location.line();
     assert_function = location.function_name();
+
+    if (firmware::led::ws2812) {
+        for (int i = 0; i < 10; i++)
+            board_delay_ms(10);
+        firmware::led::ws2812->set_value(255, 0, 0);
+    }
 
     __builtin_trap();
 }

--- a/firmware/rmcs_board/app/src/utility/lazy.hpp
+++ b/firmware/rmcs_board/app/src/utility/lazy.hpp
@@ -11,6 +11,8 @@
 
 namespace librmcs::firmware::utility {
 
+// Lazy-initialized object with deferred construction.
+// Thread-safe single-time initialization guarded by interrupt lock.
 template <typename T, typename... Args>
 class Lazy {
 public:
@@ -25,6 +27,11 @@ public:
 
     constexpr ~Lazy() {} // No need to deconstruct
 
+    /*!
+     * @brief Construct the object on first call; no-op on subsequent calls.
+     * @return Reference to the constructed object
+     * @note Thread-safe. Uses interrupt lock for atomic state transitions.
+     */
     constexpr T& init() {
         const InterruptLockGuard guard;
 
@@ -44,16 +51,46 @@ public:
         return object_;
     }
 
+    /*!
+     * @brief Get pointer to the constructed object, or nullptr if not yet
+     *        initialized.
+     * @return Pointer to the object, or nullptr if not yet initialized
+     * @note Does not assert on uninitialized state. Check return before use.
+     */
+    constexpr T* try_get() {
+        if (!static_cast<bool>(*this))
+            return nullptr;
+        return std::addressof(object_);
+    }
+
+    /*!
+     * @brief Get pointer to the constructed object
+     * @return Pointer to the constructed object
+     * @warning Must only be called after init(). Asserts if uninitialized
+     *          in debug builds.
+     */
     constexpr T* get() {
         core::utility::assert_debug(static_cast<bool>(*this));
         return std::addressof(object_);
     }
 
+    /*!
+     * @brief Member access through the constructed object
+     * @return Pointer to the constructed object
+     * @warning Must only be called after init(). Asserts if uninitialized
+     *          in debug builds.
+     */
     constexpr T* operator->() {
         core::utility::assert_debug(static_cast<bool>(*this));
         return std::addressof(object_);
     }
 
+    /*!
+     * @brief Dereference to access the constructed object
+     * @return Reference to the constructed object
+     * @warning Must only be called after init(). Asserts if uninitialized
+     *          in debug builds.
+     */
     constexpr T& operator*() {
         core::utility::assert_debug(static_cast<bool>(*this));
         return object_;

--- a/firmware/rmcs_board/boards/lite/app/board_app.cpp
+++ b/firmware/rmcs_board/boards/lite/app/board_app.cpp
@@ -11,6 +11,7 @@
 #include <hpm_mcan_regs.h>
 #include <hpm_pmic_iomux.h>
 #include <hpm_soc.h>
+#include <hpm_soc_feature.h>
 #include <hpm_soc_irq.h>
 #include <hpm_spi_regs.h>
 #include <hpm_uart_regs.h>
@@ -137,9 +138,20 @@ uint32_t init_spi(SPI_Type* ptr) {
     return init_spi_clock(ptr);
 }
 
+void init_ws2812_pin() {
+    kWs2812Pin.configure_controller();
+    kWs2812Pin.configure_as_pwm();
+    kWs2812Pin.configure_pad_control(0);
+}
+
 void init_gpio_pins() {
     kGpioHardwareDescriptors[0].configure_pioc_function();
     kGpioHardwareDescriptors[1].configure_pioc_function();
+}
+
+uint32_t init_tick_clock() {
+    clock_add_to_group(clock_gptmr1, 0);
+    return clock_get_frequency(clock_gptmr1);
 }
 
 void init_user_button_and_switch_pins() {
@@ -175,6 +187,9 @@ void gpio_bmi088_int_isr() {
 
 SDK_DECLARE_EXT_ISR_M(IRQn_GPIO0_Y, gpio_y_isr)
 void gpio_y_isr() { gpio_irq_handler(GPIO_DI_GPIOY); }
+
+SDK_DECLARE_EXT_ISR_M(IRQn_GPTMR1, tick_isr)
+void tick_isr() { tick_clock_irq_handler(); }
 
 SDK_DECLARE_EXT_ISR_M(BOARD_CAN0(IRQn_MCAN, ), can0_isr)
 void can0_isr() { can_irq_handler(0); }

--- a/firmware/rmcs_board/boards/lite/app/board_app.hpp
+++ b/firmware/rmcs_board/boards/lite/app/board_app.hpp
@@ -55,6 +55,11 @@ constexpr GpioPin kUserHsFsSwitchPin = make_gpio_pin<gpiom_soc_gpio0, 'A', 31, f
 
 void init_user_button_and_switch_pins();
 
+constexpr AnalogGpioPin kWs2812Pin = {
+    make_gpio_pin<gpiom_soc_gpio0, 'A', 6>(), HPM_PWM1_BASE, IOC_PA06_FUNC_CTL_PWM1_P_6, 6};
+
+void init_ws2812_pin();
+
 inline constexpr AnalogGpioPin kGpioHardwareDescriptors[]{
     make_gpio_pin<gpiom_soc_gpio0, 'Y', 1>(),
     make_gpio_pin<gpiom_soc_gpio0, 'Y', 0>(),
@@ -65,5 +70,10 @@ static_assert(board::spec::kGpioDescriptors.size() == std::size(board::kGpioHard
 
 void init_gpio_pins();
 void gpio_irq_handler(uint32_t port_index);
+
+#define BOARD_TICK_CLOCK HPM_GPTMR1
+
+uint32_t init_tick_clock();
+void tick_clock_irq_handler();
 
 } // namespace librmcs::firmware::board

--- a/firmware/rmcs_board/boards/pro/app/board_app.cpp
+++ b/firmware/rmcs_board/boards/pro/app/board_app.cpp
@@ -202,8 +202,21 @@ void init_user_button_and_switch_pins() {
     kUserHsFsSwitchPin.configure_as_input();
 }
 
+void init_ws2812_pin() {
+    // WS2812 is not populated until next hardware revision.
+    // Configure as input to prevent driving the line.
+    kWs2812Pin.configure_controller();
+    kWs2812Pin.configure_as_gpio();
+    kWs2812Pin.configure_as_input();
+}
+
 void init_gpio_pins() {
     // Intentionally empty: No PIOC pins need to be configured.
+}
+
+uint32_t init_tick_clock() {
+    clock_add_to_group(clock_gptmr1, 0);
+    return clock_get_frequency(clock_gptmr1);
 }
 
 SDK_DECLARE_EXT_ISR_M(IRQn_GPIO0_A, gpio_a_isr)
@@ -224,6 +237,9 @@ void gpio_bmi088_int_accel_isr() {
     }
     gpio_irq_handler(GPIO_DI_GPIOY);
 }
+
+SDK_DECLARE_EXT_ISR_M(IRQn_GPTMR1, tick_isr)
+void tick_isr() { tick_clock_irq_handler(); }
 
 SDK_DECLARE_EXT_ISR_M(BOARD_CAN0(IRQn_MCAN, ), can0_isr)
 void can0_isr() { can_irq_handler(0); }

--- a/firmware/rmcs_board/boards/pro/app/board_app.hpp
+++ b/firmware/rmcs_board/boards/pro/app/board_app.hpp
@@ -57,6 +57,11 @@ constexpr GpioPin kUserHsFsSwitchPin = make_gpio_pin<gpiom_soc_gpio0, 'Y', 4, fa
 
 void init_user_button_and_switch_pins();
 
+constexpr AnalogGpioPin kWs2812Pin = {
+    make_gpio_pin<gpiom_soc_gpio0, 'B', 4>(), HPM_PWM1_BASE, IOC_PB04_FUNC_CTL_PWM1_P_0, 0};
+
+void init_ws2812_pin();
+
 inline constexpr AnalogGpioPin kGpioHardwareDescriptors[]{
     {make_gpio_pin<gpiom_soc_gpio0, 'B', 0>(), HPM_PWM0_BASE, IOC_PB00_FUNC_CTL_PWM0_P_0, 0},
     {make_gpio_pin<gpiom_soc_gpio0, 'B', 1>(), HPM_PWM0_BASE, IOC_PB01_FUNC_CTL_PWM0_P_1, 1},
@@ -80,5 +85,10 @@ static_assert(board::spec::kGpioDescriptors.size() == std::size(board::kGpioHard
 
 void init_gpio_pins();
 void gpio_irq_handler(uint32_t port_index);
+
+#define BOARD_TICK_CLOCK HPM_GPTMR1
+
+uint32_t init_tick_clock();
+void tick_clock_irq_handler();
 
 } // namespace librmcs::firmware::board


### PR DESCRIPTION
- Expose USB, UART, and CAN backpressure plus fatal asserts through a shared status light path so board health is visible without a debugger.
- Keep the pro variant initialized but non-driving so the same firmware path is ready for the next hardware revision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## WS2812 状态指示灯反馈功能（更新）

该拉取请求为固件添加了共享的 WS2812 状态指示灯路径，用于在无需调试器的情况下通过可视反馈暴露 USB/UART/CAN 的背压状态及致命断言信息；同时保留 pro 硬件变体的初始化但不驱动线路，以便未来硬件修订复用相同固件路径。

### 核心功能
- WS2812 驱动（firmware/rmcs_board/app/src/led/ws2812.hpp）
  - 基于 PWM + DMA 实现的 WS2812 控制器，支持 24 位 GRB 输出与亮度缩放。
  - set_value(red, green, blue) 将颜色转换为 GRB 比较表并通过 DMA 推送，返回是否接受更新。
- LED 状态管理（firmware/rmcs_board/app/src/led/led.hpp）
  - 新增 Led 类，使用两个原子“缓冲满重置”计数器追踪上行/下行背压（计数器置为 5000 周期）。
  - update(tick) 原子递减计数器并根据上/下行状态、相位等选择 RGB 输出；正常运行时显示绿色亮度循环。
  - 提供全局延迟初始化实例 led（utility::Lazy 用于延迟初始化）。
- 周期时钟与中断（firmware/rmcs_board/app/src/timer/tick.hpp/.cpp）
  - 新增 Tick 类，配置约 1kHz 的 GPTMR 定时中断；irq_handler 增加 tick 计数并驱动 LED 更新。
  - 新增板级中断转发函数 tick_clock_irq_handler。

### 集成点（缓冲区/传输失败 -> 指示灯）
- USB 上行缓冲满（firmware/rmcs_board/app/src/usb/interrupt_safe_buffer.hpp）：调用 led::led->uplink_buffer_full()。
- UART 下行缓冲满（firmware/rmcs_board/app/src/uart/uart.hpp）：在 enqueue 失败时调用 led::led->downlink_buffer_full()。
- CAN 下行（firmware/rmcs_board/app/src/can/can.hpp）：检查 mcan_transmit_via_txfifo_nonblocking 返回值，失败时调用 led::led->downlink_buffer_full()。

### 断言视觉反馈
- assert_func（firmware/rmcs_board/app/src/utility/assert.cpp）
  - 在记录断言位置前禁用全局中断，并在条件允许时触发 WS2812 红色序列（若可用）作为致命断言的视觉提示，然后调用 __builtin_trap()。

### Lazy 访问语义变更（重要，破坏性）
- utility::Lazy 的访问契约已调整以避免断言路径中的递归断言：
  - 非断言的探测路径（在提交信息与部分文件中以 try_get 或非断言 get 实现/文档说明出现）：在未初始化时返回 nullptr，从而允许在断言/故障处理路径安全地探测可用性而不触发断言递归。
  - operator->() 与 operator*() 保持严格语义（仍会在未初始化时断言）。
- 注意：调用方必须在解引用之前检查返回的指针（破坏性变更：探测前请检查指针是否为 nullptr）。

### 板级与 GPIO 改动
- analog_gpio_pin.hpp：新增 constexpr 访问器 pwm_base()/pwm_ioc_function()/pwm_output_index()，并将 pwm_instance() 移至 public。
- Lite/Pro 板级（firmware/rmcs_board/boards/*/app）
  - 新增 kWs2812Pin 描述、init_ws2812_pin()（Pro 版将引脚设为输入以避免驱动未焊接器件）、init_tick_clock() 以及 GPTMR1 的 ISR 转发（tick_isr/tick_clock_irq_handler）。
- 应用初始化（firmware/rmcs_board/app/src/app.cpp）
  - 在应用构造期间初始化 LED 子系统与周期时钟（在引导/传感器初始化之后）。

### 其它
- 新增或修改的导出实体：Led、Ws2812、Tick 类及对应的延迟初始化全局实例；若干板级初始化函数与宏。
- 若干文件的实现细节与注释扩充，部分文件引入了必要的头文件以支持中断控制与 WS2812 操作。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->