### PR TITLE
fix(firmware/rmcs_board): Disable CAN automatic retransmission

### DIFF
--- a/firmware/rmcs_board/app/src/can/can.hpp
+++ b/firmware/rmcs_board/app/src/can/can.hpp
@@ -56,6 +56,7 @@ public:
         config.ram_config.txbuf_dedicated_txbuf_elem_count = 0;
         config.ram_config.txbuf_fifo_or_queue_elem_count = MCAN_TXBUF_SIZE_CAN_DEFAULT;
         config.ram_config.txfifo_or_txqueue_mode = MCAN_TXBUF_OPERATION_MODE_FIFO;
+        config.disable_auto_retransmission = true;
 
         mcan_init(can_base_, &config, can_source_clock_freq);
         mcan_enable_interrupts(can_base_, MCAN_INT_RXFIFO0_NEW_MSG);


### PR DESCRIPTION
Align rmcs_board CAN behavior with c_board by disabling hardware automatic retransmission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 摘要

本PR禁用了rmcs_board固件中CAN控制器的硬件自动重传功能，使其行为与c_board保持一致。

## 变更详情

**文件：** `firmware/rmcs_board/app/src/can/can.hpp`

在`Can`构造函数中的MCAN配置初始化处新增配置项：
- 添加 `config.disable_auto_retransmission = true;` 以禁用CAN自动重传功能

这是唯一的代码变更，其余逻辑保持不变。

## 影响范围

- 仅影响rmcs_board的CAN驱动模块
- 无公共API签名变更
- 代码审查难度：中等

<!-- end of auto-generated comment: release notes by coderabbit.ai -->