### PR TITLE
feat(host)!: Add thread setup support to advanced options

### DIFF
--- a/host/include/librmcs/agent/common.hpp
+++ b/host/include/librmcs/agent/common.hpp
@@ -1,9 +1,89 @@
 #pragma once
 
+#include <functional>
+#include <type_traits>
+#include <utility>
+
 namespace librmcs::agent {
 
-struct AdvancedOptions {
+/**
+ * @brief Advanced transport options passed during agent construction.
+ *
+ * `bind_advanced_options()` returns an object derived from `AdvancedOptions` whose `thread_setup`
+ * callback depends on state stored in that derived object. Copying or moving the base type would
+ * slice away that state while retaining a now-dangling function pointer, so `AdvancedOptions` is
+ * intentionally non-copyable and non-movable.
+ *
+ * Construct `AdvancedOptions` directly during agent construction, or explicitly copy the required
+ * plain data fields into a fresh `AdvancedOptions` instance instead of copying an existing object.
+ *
+ * @warning Never copy, assign, or reuse any function pointer from an object returned by
+ * `bind_advanced_options()` in any other `AdvancedOptions` instance; doing so is undefined
+ * behavior.
+ */
+class AdvancedOptions {
+public:
+    AdvancedOptions() = default;
+
+    AdvancedOptions(const AdvancedOptions&) = delete;
+    AdvancedOptions& operator=(const AdvancedOptions&) = delete;
+    AdvancedOptions(AdvancedOptions&&) = delete;
+    AdvancedOptions& operator=(AdvancedOptions&&) = delete;
+
+    ~AdvancedOptions() = default;
+
     bool dangerously_skip_version_checks = false;
+
+    /**
+     * @brief Callback invoked on the transport event thread before transport I/O handling begins.
+     *
+     * This hook is intended only for per-thread environment setup, such as thread priority,
+     * CPU affinity, thread naming, or other OS-level thread configuration.
+     *
+     * @warning This callback runs during transport construction, before `Handler` and the
+     * enclosing agent object finish construction.
+     * @warning The callback must not access the agent object being constructed, any of its
+     * members, or any transport/protocol APIs. In particular, do not capture and use `this`
+     * from the constructing agent object.
+     */
+    void (*thread_setup)(const AdvancedOptions&) noexcept = nullptr;
+
+    AdvancedOptions& set_dangerously_skip_version_checks(bool value) {
+        dangerously_skip_version_checks = value;
+        return *this;
+    }
+
+    AdvancedOptions& set_thread_setup(void (*value)(const AdvancedOptions&) noexcept) {
+        thread_setup = value;
+        return *this;
+    }
 };
+
+/**
+ * @brief Binds callable to `AdvancedOptions`.
+ *
+ * @warning The returned object must outlive any use of its function pointers.
+ * @warning Do not store, copy, move, or slice the returned object as `AdvancedOptions`.
+ */
+template <typename FunctorT>
+requires std::is_nothrow_invocable_v<const std::decay_t<FunctorT>&>
+auto bind_advanced_options(FunctorT&& thread_setup_impl) {
+    using Functor = std::decay_t<FunctorT>;
+
+    class OptionsImpl : public AdvancedOptions {
+    public:
+        explicit OptionsImpl(Functor thread_setup_impl)
+            : thread_setup_impl_(std::move(thread_setup_impl)) {
+            thread_setup = [](const AdvancedOptions& self) noexcept {
+                std::invoke(static_cast<const OptionsImpl&>(self).thread_setup_impl_);
+            };
+        }
+
+    private:
+        Functor thread_setup_impl_;
+    };
+
+    return OptionsImpl{std::forward<FunctorT>(thread_setup_impl)};
+}
 
 } // namespace librmcs::agent

--- a/host/src/protocol/handler.cpp
+++ b/host/src/protocol/handler.cpp
@@ -209,12 +209,7 @@ Handler::Handler(
     uint16_t usb_vid, int32_t usb_pid, std::string_view serial_filter,
     const agent::AdvancedOptions& options, data::DataCallback& callback)
     : impl_(new Impl(
-          transport::usb::create_transport(
-              usb_vid, usb_pid, serial_filter,
-              transport::usb::ConnectionOptions{
-                  .dangerously_skip_version_checks = options.dangerously_skip_version_checks,
-              }),
-          callback)) {}
+          transport::usb::create_transport(usb_vid, usb_pid, serial_filter, options), callback)) {}
 
 Handler::Handler(Handler&& other) noexcept
     : impl_(std::exchange(other.impl_, nullptr)) {}

--- a/host/src/transport/transport.hpp
+++ b/host/src/transport/transport.hpp
@@ -8,6 +8,7 @@
 #include <string_view>
 
 #include "core/src/protocol/constant.hpp"
+#include "librmcs/agent/common.hpp"
 
 namespace librmcs::host::transport {
 
@@ -140,9 +141,7 @@ public:
 
 namespace usb {
 
-struct ConnectionOptions {
-    bool dangerously_skip_version_checks = false;
-};
+using ConnectionOptions = agent::AdvancedOptions;
 
 std::unique_ptr<Transport> create_transport(
     uint16_t usb_vid, int32_t usb_pid, std::string_view serial_filter,

--- a/host/src/transport/usb/usb.cpp
+++ b/host/src/transport/usb/usb.cpp
@@ -45,7 +45,20 @@ public:
         }};
 
         init_transmit_transfers();
-        event_thread_ = std::thread{[this]() { handle_events(); }};
+
+        if (options.thread_setup) {
+            std::atomic<bool> thread_setup_done{false};
+            event_thread_ = std::thread{[this, &options, &thread_setup_done]() {
+                options.thread_setup(options);
+                thread_setup_done.store(true, std::memory_order_release);
+                thread_setup_done.notify_one();
+                handle_events();
+            }};
+            // Wait until thread_setup returns, so any bound options state remains alive.
+            thread_setup_done.wait(false, std::memory_order_acquire);
+        } else {
+            event_thread_ = std::thread{[this]() { handle_events(); }};
+        }
 
         rollback_on_failure.disable();
     }


### PR DESCRIPTION
- Introduce `thread_setup` in `agent::AdvancedOptions` so callers can configure the transport event thread before it starts handling USB I/O.
- Add `bind_advanced_options()` to bind stateful nothrow callables without introducing `std::function` into the binary interface. The transport now waits until `thread_setup` returns before continuing construction, so any bound temporary state remains alive during the callback.
- Also document the lifetime and slicing constraints of bound advanced options, and clarify that `thread_setup` is only for per-thread OS-level setup such as priority or CPU affinity.

BREAKING CHANGE: `agent::AdvancedOptions` is now non-copyable and non-movable, and no longer preserves the previous aggregate-style usage. The USB transport connection options alias now reuses `agent::AdvancedOptions`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 拉取请求摘要

### 概述
本PR为 `agent::AdvancedOptions` 配置添加了线程设置支持，允许调用者在USB I/O操作开始前配置传输事件线程。这是一个**破坏性变更**，涉及多个组件的API调整。

### 核心变更

#### 1. agent::AdvancedOptions 结构升级（host/include/librmcs/agent/common.hpp）
- 将 `AdvancedOptions` 从简单的struct转换为class，现在**不支持拷贝和移动**
- 删除了拷贝/移动构造函数和赋值操作符
- 添加了新的 `thread_setup` 回调函数指针：`void (*)(const AdvancedOptions&) noexcept`
- 新增链式setter方法：
  - `set_dangerously_skip_version_checks(bool)`
  - `set_thread_setup(void (*)(const AdvancedOptions&) noexcept)`

#### 2. 绑定高级选项函数（host/include/librmcs/agent/common.hpp）
- 引入模板函数 `bind_advanced_options(FunctorT&& thread_setup_impl)`
- 支持绑定有状态的可调用对象（闭包、仿函数等）到函数指针
- 内部通过创建派生类 `OptionsImpl` 来保存传入的实现，使用 `std::invoke` 适配
- 避免了在二进制接口中引入 `std::function`，保持API的轻量性
- 文档说明了绑定对象生命周期的约束和使用方式

#### 3. 传输层选项统一（host/src/transport/transport.hpp）
- `transport::usb::ConnectionOptions` 从独立的struct变更为 `agent::AdvancedOptions` 的类型别名
- `transport.hpp` 包含了 `librmcs/agent/common.hpp` 头文件

#### 4. Handler构造函数更新（host/src/protocol/handler.cpp）
- 现在将完整的 `options` 对象传递给 `transport::usb::create_transport()`，而非仅映射 `dangerously_skip_version_checks` 字段

#### 5. USB事件线程启动同步（host/src/transport/usb/usb.cpp）
- 事件处理线程启动逻辑新增了对 `thread_setup` 回调的条件化处理
- 当提供 `thread_setup` 时，在新线程内先执行该回调，使用 `std::atomic<bool>` 和等待/通知机制同步
- 确保 `thread_setup` 完成后主线程才继续构造，防止绑定回调所依赖的临时状态失效

### 使用指导
- `thread_setup` 回调仅用于**每线程操作系统级别的配置**（如线程优先级、CPU亲和度设置）
- 调用者需注意 `bind_advanced_options()` 返回的对象生命周期约束，确保绑定的可调用对象在回调执行期间保持有效
- 文档警告不要在 `thread_setup` 中访问正在构造的agent对象或传输/协议API

### 破坏性变更
由于 `AdvancedOptions` 不再支持拷贝和移动，现有代码使用聚合初始化模式（如 `AdvancedOptions{...}` 或赋值）需要改为使用setter方法或 `bind_advanced_options()` 函数。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->