### PR TITLE
feat(protocol): Add USB session handshake

### DIFF
--- a/core/include/librmcs/data/datas.hpp
+++ b/core/include/librmcs/data/datas.hpp
@@ -30,6 +30,20 @@ enum class DataId : uint8_t {
     kUart3 = 14,
 
     kImu = 15,
+
+    kSession = 16,
+};
+
+enum class SessionType : uint8_t {
+    kStart = 0,
+    kStartAck = 1,
+    kKeepalive = 2,
+    kKeepaliveAck = 3,
+};
+
+struct SessionControlView {
+    SessionType type;
+    uint32_t nonce;
 };
 
 struct CanDataView {

--- a/core/src/protocol/deserializer.cpp
+++ b/core/src/protocol/deserializer.cpp
@@ -53,6 +53,7 @@ coroutine::LifoTask<void> Deserializer::process_stream() {
         case FieldId::kUart3: success = co_await process_uart_field(id); break;
         case FieldId::kGpio: success = co_await process_gpio_field(id); break;
         case FieldId::kImu: success = co_await process_imu_field(id); break;
+        case FieldId::kSession: success = co_await process_session_field(id); break;
         default: break;
         }
         if (!success)
@@ -314,6 +315,22 @@ coroutine::LifoTask<bool> Deserializer::process_imu_field(FieldId) {
     }
     default: co_return false;
     }
+    co_return true;
+}
+
+coroutine::LifoTask<bool> Deserializer::process_session_field(FieldId) {
+    const auto* header_bytes = co_await peek_bytes(sizeof(SessionHeader));
+    if (!header_bytes) [[unlikely]]
+        co_return false;
+
+    auto header = SessionHeader::CRef{header_bytes};
+    data::SessionControlView data_view{};
+    data_view.type = header.get<SessionHeader::Type>();
+    data_view.nonce = header.get<SessionHeader::Nonce>();
+    consume_peeked();
+
+    callback_.session_control_deserialized_callback(data_view);
+
     co_return true;
 }
 

--- a/core/src/protocol/deserializer.hpp
+++ b/core/src/protocol/deserializer.hpp
@@ -46,6 +46,8 @@ public:
 
     virtual void temperature_deserialized_callback(const data::TemperatureDataView& data) = 0;
 
+    virtual void session_control_deserialized_callback(const data::SessionControlView& data) = 0;
+
     virtual void error_callback() = 0;
 };
 
@@ -119,6 +121,8 @@ private:
     coroutine::LifoTask<bool> process_gpio_field(FieldId field_id);
 
     coroutine::LifoTask<bool> process_imu_field(FieldId field_id);
+
+    coroutine::LifoTask<bool> process_session_field(FieldId field_id);
 
     // Await until at least `size` contiguous bytes are available at the current read position.
     // Returns a pointer to a contiguous region of at least `size` bytes.

--- a/core/src/protocol/protocol.hpp
+++ b/core/src/protocol/protocol.hpp
@@ -48,6 +48,11 @@ struct UartHeaderExtendedLayout {
     using DataLengthExtended = BitfieldMember<6, 10>;
 };
 
+struct SessionHeaderLayout {
+    using Type = BitfieldMember<4, 4, data::SessionType>;
+    using Nonce = BitfieldMember<8, 32, uint32_t>;
+};
+
 } // namespace layouts
 
 struct FieldHeader
@@ -81,6 +86,10 @@ struct UartHeaderExtended
     : utility::Bitfield<2>
     , layouts::UartHeaderLayout
     , layouts::UartHeaderExtendedLayout {};
+
+struct SessionHeader
+    : utility::Bitfield<5>
+    , layouts::SessionHeaderLayout {};
 
 struct GpioHeader : utility::Bitfield<2> {
     enum class PayloadEnum : uint8_t {

--- a/core/src/protocol/serializer.hpp
+++ b/core/src/protocol/serializer.hpp
@@ -380,6 +380,25 @@ public:
         return SerializeResult::kSuccess;
     }
 
+    SerializeResult write_session_control(const data::SessionControlView& view) noexcept {
+        const std::size_t required = required_session_size();
+
+        auto dst = buffer_.allocate(required);
+        LIBRMCS_VERIFY_LIKELY(!dst.empty(), SerializeResult::kBadAlloc);
+        utility::assert_debug(dst.size() == required);
+        std::byte* cursor = dst.data();
+
+        write_field_header(cursor, FieldId::kSession);
+
+        auto header = SessionHeader::Ref(cursor);
+        cursor += sizeof(SessionHeader);
+        header.set<SessionHeader::Type>(view.type);
+        header.set<SessionHeader::Nonce>(view.nonce);
+
+        utility::assert_debug(cursor == dst.data() + dst.size());
+        return SerializeResult::kSuccess;
+    }
+
 private:
     static constexpr bool use_extended_field_header(FieldId field_id) {
         utility::assert_debug(field_id != FieldId::kExtend);
@@ -486,6 +505,13 @@ private:
         const std::size_t total = (field_header_bytes + imu_header_bytes - 1) + payload_bytes;
         utility::assert_debug(total <= kProtocolBufferSize);
 
+        return total;
+    }
+
+    static constexpr std::size_t required_session_size() {
+        constexpr std::size_t total = required_field_header_size(FieldId::kSession)
+                                    + sizeof(SessionHeader) - sizeof(FieldHeader);
+        utility::assert_debug(total <= kProtocolBufferSize);
         return total;
     }
 

--- a/firmware/c_board/app/src/usb/interrupt_safe_buffer.hpp
+++ b/firmware/c_board/app/src/usb/interrupt_safe_buffer.hpp
@@ -27,8 +27,9 @@ public:
 
     std::span<std::byte> allocate(size_t size) noexcept override {
         core::utility::assert_debug(size <= core::protocol::kProtocolBufferSize);
-        if (is_locked_.test(std::memory_order::relaxed))
+        if (is_locked_.test(std::memory_order::relaxed)) {
             return {};
+        }
 
         auto out = out_.load(std::memory_order::relaxed);
 
@@ -102,36 +103,27 @@ public:
     }
 
     void clear() {
+        const bool was_locked = is_locked_.test_and_set(std::memory_order::relaxed);
+        core::utility::assert_debug(!was_locked);
+
         auto in = in_.load(std::memory_order::relaxed);
         auto out = out_.load(std::memory_order::relaxed);
 
         auto readable = in - out;
-        if (!readable)
-            return;
+        if (readable) {
+            auto offset = out & kMask;
+            auto slice = std::min(readable, kBatchCount - offset);
 
-        auto offset = out & kMask;
-        auto slice = std::min(readable, kBatchCount - offset);
+            for (size_t i = 0; i < slice; i++)
+                batches_[offset + i].reset();
+            for (size_t i = 0; i < readable - slice; i++)
+                batches_[i].reset();
 
-        for (size_t i = 0; i < slice; i++)
-            batches_[offset + i].reset();
-        for (size_t i = 0; i < readable - slice; i++)
-            batches_[i].reset();
+            std::atomic_signal_fence(std::memory_order::release);
+            out_.store(in, std::memory_order::relaxed);
+        }
 
-        std::atomic_signal_fence(std::memory_order::release);
-        out_.store(in, std::memory_order::relaxed);
-    }
-
-    bool try_lock() { return !is_locked_.test_and_set(std::memory_order::relaxed); }
-
-    bool try_unlock_and_clear() {
-        if (!is_locked_.test(std::memory_order::relaxed))
-            return false;
-
-        // Unlocking drops stale queued batches from the last not-ready cycle before
-        // new ISR writes are accepted.
-        clear();
         is_locked_.clear(std::memory_order::relaxed);
-        return true;
     }
 
 private:

--- a/firmware/c_board/app/src/usb/vendor.cpp
+++ b/firmware/c_board/app/src/usb/vendor.cpp
@@ -31,13 +31,20 @@ void tud_dfu_runtime_reboot_to_dfu_cb() {
     NVIC_SystemReset();
 }
 
-void tud_suspend_cb(bool remote_wakeup_en) { (void)remote_wakeup_en; }
+void tud_suspend_cb(bool remote_wakeup_en) {
+    (void)remote_wakeup_en;
+    usb::vendor->deactivate_session();
+    usb::vendor->finish_downlink_transfer();
+}
 
 void tud_resume_cb() {}
 
 void tud_mount_cb() {}
 
-void tud_umount_cb() {}
+void tud_umount_cb() {
+    usb::vendor->deactivate_session();
+    usb::vendor->finish_downlink_transfer();
+}
 
 } // extern "C"
 

--- a/firmware/c_board/app/src/usb/vendor.hpp
+++ b/firmware/c_board/app/src/usb/vendor.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <algorithm>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
 #include <span>
 
 #include <class/vendor/vendor_device.h>
-#include <device/usbd.h>
 #include <tusb.h>
 
 #include "core/include/librmcs/data/datas.hpp"
@@ -20,6 +20,7 @@
 #include "core/src/utility/immovable.hpp"
 #include "firmware/c_board/app/src/can/can.hpp"
 #include "firmware/c_board/app/src/gpio/gpio.hpp"
+#include "firmware/c_board/app/src/timer/timer.hpp"
 #include "firmware/c_board/app/src/uart/uart.hpp"
 #include "firmware/c_board/app/src/usb/interrupt_safe_buffer.hpp"
 #include "firmware/c_board/app/src/usb/usb_descriptors.hpp"
@@ -35,6 +36,7 @@ public:
 
     static constexpr size_t kMaxPacketSize = 64;
     static constexpr std::size_t kGpioChannelCount = std::size(spec::c_board::kGpioDescriptors);
+    static constexpr auto kSessionLease = std::chrono::milliseconds{1000};
 
     Vendor() {
         usb::usb_descriptors.init();
@@ -43,15 +45,20 @@ public:
 
     core::protocol::Serializer& serializer() { return serializer_; }
 
+    void deactivate_session() { session_established_ = false; }
+
     void handle_downlink(std::span<const std::byte> buffer, bool finished) {
         deserializer_.feed(buffer);
         if (finished)
             deserializer_.finish_transfer();
     }
 
+    void finish_downlink_transfer() { deserializer_.finish_transfer(); }
+
     bool try_transmit() {
-        if (!tud_ready()) {
-            transmit_buffer_.try_lock();
+        refresh_session_state();
+
+        if (!session_established_) {
             return false;
         }
 
@@ -59,7 +66,6 @@ public:
             return false;
 
         if (!transmitting_batch_) {
-            transmit_buffer_.try_unlock_and_clear();
             transmitting_batch_ = transmit_buffer_.pop_batch();
         }
         if (!transmitting_batch_)
@@ -87,8 +93,23 @@ public:
     }
 
 private:
+    void activate_session(uint32_t nonce) {
+        if (transmitting_batch_) {
+            transmit_buffer_.release_batch(transmitting_batch_);
+            transmitting_batch_ = nullptr;
+            transmitted_size_ = 0;
+        }
+        transmit_buffer_.clear();
+
+        current_session_nonce_ = nonce;
+        last_session_refresh_ = timer::timer->timepoint48();
+        session_established_ = true;
+    }
+
     void can_deserialized_callback(
         core::protocol::FieldId id, const data::CanDataView& data) override {
+        if (!session_established_)
+            return;
         switch (id) {
         case data::DataId::kCan1: can::can1->handle_downlink(data); break;
         case data::DataId::kCan2: can::can2->handle_downlink(data); break;
@@ -98,6 +119,8 @@ private:
 
     void uart_deserialized_callback(
         core::protocol::FieldId id, const data::UartDataView& data) override {
+        if (!session_established_)
+            return;
         switch (id) {
         case data::DataId::kUart1: uart::uart1->handle_downlink(data); break;
         case data::DataId::kUart2: uart::uart2->handle_downlink(data); break;
@@ -107,6 +130,8 @@ private:
 
     void gpio_digital_data_deserialized_callback(
         uint8_t channel_index, const data::GpioDigitalDataView& data) override {
+        if (!session_established_)
+            return;
         if (channel_index >= kGpioChannelCount)
             return;
 
@@ -119,6 +144,8 @@ private:
 
     void gpio_analog_data_deserialized_callback(
         uint8_t channel_index, const data::GpioAnalogDataView& data) override {
+        if (!session_established_)
+            return;
         if (channel_index >= kGpioChannelCount)
             return;
 
@@ -131,6 +158,8 @@ private:
 
     void gpio_digital_read_config_deserialized_callback(
         uint8_t channel_index, const data::GpioReadConfigView& data) override {
+        if (!session_established_)
+            return;
         if (channel_index >= kGpioChannelCount)
             return;
 
@@ -159,7 +188,52 @@ private:
         (void)data;
     }
 
-    void error_callback() override { core::utility::assert_failed_always(); }
+    void session_control_deserialized_callback(const data::SessionControlView& data) override {
+        switch (data.type) {
+        case data::SessionType::kStart: {
+            const bool same_session = session_established_ && data.nonce == current_session_nonce_;
+
+            if (!same_session)
+                activate_session(data.nonce);
+            else
+                last_session_refresh_ = timer::timer->timepoint48();
+
+            const auto result = serializer_.write_session_control(
+                {.type = data::SessionType::kStartAck, .nonce = data.nonce});
+            core::utility::assert_always(
+                result != core::protocol::Serializer::SerializeResult::kInvalidArgument);
+            break;
+        }
+        case data::SessionType::kKeepalive:
+            if (!session_established_ || data.nonce != current_session_nonce_)
+                return;
+
+            last_session_refresh_ = timer::timer->timepoint48();
+            {
+                const auto result = serializer_.write_session_control(
+                    {.type = data::SessionType::kKeepaliveAck, .nonce = data.nonce});
+                core::utility::assert_always(
+                    result != core::protocol::Serializer::SerializeResult::kInvalidArgument);
+            }
+            break;
+        default: return;
+        }
+    }
+
+    void error_callback() override {
+        // TODO: Report USB downlink deserialization errors through a dedicated error path.
+    }
+
+    void refresh_session_state() {
+        if (!session_established_)
+            return;
+
+        if (!timer::timer->check_expired(
+                last_session_refresh_, timer::Timer::to_duration48_checked(kSessionLease)))
+            return;
+
+        deactivate_session();
+    }
 
     core::protocol::Deserializer deserializer_{*this};
 
@@ -168,6 +242,9 @@ private:
 
     const InterruptSafeBuffer::Batch* transmitting_batch_ = nullptr;
     size_t transmitted_size_ = 0;
+    bool session_established_ = false;
+    uint32_t current_session_nonce_ = 0;
+    timer::Timer::TimePoint48 last_session_refresh_ = timer::Timer::TimePoint48::min();
 };
 
 inline constinit Vendor::Lazy vendor;

--- a/firmware/rmcs_board/app/src/usb/interrupt_safe_buffer.hpp
+++ b/firmware/rmcs_board/app/src/usb/interrupt_safe_buffer.hpp
@@ -27,8 +27,9 @@ public:
 
     std::span<std::byte> allocate(size_t size) noexcept override {
         core::utility::assert_debug(size <= core::protocol::kProtocolBufferSize);
-        if (is_locked_.test(std::memory_order::relaxed))
+        if (is_locked_.test(std::memory_order::relaxed)) {
             return {};
+        }
 
         auto out = out_.load(std::memory_order::relaxed);
 
@@ -102,36 +103,27 @@ public:
     }
 
     void clear() {
+        const bool was_locked = is_locked_.test_and_set(std::memory_order::relaxed);
+        core::utility::assert_debug(!was_locked);
+
         auto in = in_.load(std::memory_order::relaxed);
         auto out = out_.load(std::memory_order::relaxed);
 
         auto readable = in - out;
-        if (!readable)
-            return;
+        if (readable) {
+            auto offset = out & kMask;
+            auto slice = std::min(readable, kBatchCount - offset);
 
-        auto offset = out & kMask;
-        auto slice = std::min(readable, kBatchCount - offset);
+            for (size_t i = 0; i < slice; i++)
+                batches_[offset + i].reset();
+            for (size_t i = 0; i < readable - slice; i++)
+                batches_[i].reset();
 
-        for (size_t i = 0; i < slice; i++)
-            batches_[offset + i].reset();
-        for (size_t i = 0; i < readable - slice; i++)
-            batches_[i].reset();
+            std::atomic_signal_fence(std::memory_order_release);
+            out_.store(in, std::memory_order::relaxed);
+        }
 
-        std::atomic_signal_fence(std::memory_order_release);
-        out_.store(in, std::memory_order::relaxed);
-    }
-
-    bool try_lock() { return !is_locked_.test_and_set(std::memory_order::relaxed); }
-
-    bool try_unlock_and_clear() {
-        if (!is_locked_.test(std::memory_order::relaxed))
-            return false;
-
-        // Unlocking drops stale queued batches from the last not-ready cycle before
-        // new ISR writes are accepted.
-        clear();
         is_locked_.clear(std::memory_order::relaxed);
-        return true;
     }
 
 private:

--- a/firmware/rmcs_board/app/src/usb/vendor.cpp
+++ b/firmware/rmcs_board/app/src/usb/vendor.cpp
@@ -27,13 +27,20 @@ void tud_vendor_rx_cb(uint8_t itf, const uint8_t* buffer, uint16_t size) {
 
 void tud_dfu_runtime_reboot_to_dfu_cb() { boot::BootMailbox::reboot_to_bootloader(); }
 
-void tud_suspend_cb(bool remote_wakeup_en) { (void)remote_wakeup_en; }
+void tud_suspend_cb(bool remote_wakeup_en) {
+    (void)remote_wakeup_en;
+    usb::vendor->deactivate_session();
+    usb::vendor->finish_downlink_transfer();
+}
 
 void tud_resume_cb() {}
 
 void tud_mount_cb() {}
 
-void tud_umount_cb() {}
+void tud_umount_cb() {
+    usb::vendor->deactivate_session();
+    usb::vendor->finish_downlink_transfer();
+}
 
 } // extern "C"
 

--- a/firmware/rmcs_board/app/src/usb/vendor.hpp
+++ b/firmware/rmcs_board/app/src/usb/vendor.hpp
@@ -20,6 +20,7 @@
 #include "core/src/utility/immovable.hpp"
 #include "firmware/rmcs_board/app/src/can/can.hpp"
 #include "firmware/rmcs_board/app/src/gpio/gpio.hpp"
+#include "firmware/rmcs_board/app/src/timer/timer.hpp"
 #include "firmware/rmcs_board/app/src/uart/uart.hpp"
 #include "firmware/rmcs_board/app/src/usb/interrupt_safe_buffer.hpp"
 #include "firmware/rmcs_board/app/src/usb/usb_descriptors.hpp"
@@ -32,6 +33,8 @@ class Vendor
     , private core::utility::Immovable {
 public:
     using Lazy = utility::Lazy<Vendor>;
+
+    static constexpr uint64_t kSessionLeaseQuarterUs = 4'000'000;
 
     Vendor() {
         usb::usb_descriptors.init();
@@ -46,15 +49,20 @@ public:
 
     core::protocol::Serializer& serializer() { return serializer_; }
 
+    void deactivate_session() { session_established_ = false; }
+
     void handle_downlink(std::span<const std::byte> buffer, bool finished) {
         deserializer_.feed(buffer);
         if (finished)
             deserializer_.finish_transfer();
     }
 
+    void finish_downlink_transfer() { deserializer_.finish_transfer(); }
+
     bool try_transmit() {
-        if (!tud_ready()) {
-            transmit_buffer_.try_lock();
+        refresh_session_state();
+
+        if (!session_established_) {
             return false;
         }
 
@@ -62,7 +70,6 @@ public:
             return false;
 
         if (!transmitting_batch_) {
-            transmit_buffer_.try_unlock_and_clear();
             transmitting_batch_ = transmit_buffer_.pop_batch();
         }
         if (!transmitting_batch_)
@@ -91,8 +98,23 @@ public:
     }
 
 private:
+    void activate_session(uint32_t nonce) {
+        if (transmitting_batch_) {
+            transmit_buffer_.release_batch(transmitting_batch_);
+            transmitting_batch_ = nullptr;
+            transmitted_size_ = 0;
+        }
+        transmit_buffer_.clear();
+
+        current_session_nonce_ = nonce;
+        last_session_refresh_quarter_us_ = timer::Timer::timestamp64_quarter_us();
+        session_established_ = true;
+    }
+
     void can_deserialized_callback(
         core::protocol::FieldId id, const data::CanDataView& data) override {
+        if (!session_established_)
+            return;
         switch (id) {
         case data::DataId::kCan0: can::can_array[0]->handle_downlink(data); break;
         case data::DataId::kCan1: can::can_array[1]->handle_downlink(data); break;
@@ -104,6 +126,8 @@ private:
 
     void uart_deserialized_callback(
         core::protocol::FieldId id, const data::UartDataView& data) override {
+        if (!session_established_)
+            return;
         switch (id) {
         case data::DataId::kUart0: uart::uart_array[0]->handle_downlink(data); break;
         case data::DataId::kUart1: uart::uart_array[1]->handle_downlink(data); break;
@@ -119,6 +143,8 @@ private:
 
     void gpio_digital_data_deserialized_callback(
         uint8_t channel_index, const data::GpioDigitalDataView& data) override {
+        if (!session_established_)
+            return;
         if (channel_index >= board::spec::kGpioDescriptors.size())
             return;
 
@@ -131,6 +157,8 @@ private:
 
     void gpio_analog_data_deserialized_callback(
         uint8_t channel_index, const data::GpioAnalogDataView& data) override {
+        if (!session_established_)
+            return;
         if (channel_index >= board::spec::kGpioDescriptors.size())
             return;
 
@@ -143,6 +171,8 @@ private:
 
     void gpio_digital_read_config_deserialized_callback(
         uint8_t channel_index, const data::GpioReadConfigView& data) override {
+        if (!session_established_)
+            return;
         if (channel_index >= board::spec::kGpioDescriptors.size())
             return;
 
@@ -171,7 +201,52 @@ private:
         (void)data;
     }
 
-    void error_callback() override { core::utility::assert_failed_always(); }
+    void session_control_deserialized_callback(const data::SessionControlView& data) override {
+        switch (data.type) {
+        case data::SessionType::kStart: {
+            const bool same_session = session_established_ && data.nonce == current_session_nonce_;
+
+            if (!same_session)
+                activate_session(data.nonce);
+            else
+                last_session_refresh_quarter_us_ = timer::Timer::timestamp64_quarter_us();
+
+            const auto result = serializer_.write_session_control(
+                {.type = data::SessionType::kStartAck, .nonce = data.nonce});
+            core::utility::assert_always(
+                result != core::protocol::Serializer::SerializeResult::kInvalidArgument);
+            break;
+        }
+        case data::SessionType::kKeepalive:
+            if (!session_established_ || data.nonce != current_session_nonce_)
+                return;
+
+            last_session_refresh_quarter_us_ = timer::Timer::timestamp64_quarter_us();
+            {
+                const auto result = serializer_.write_session_control(
+                    {.type = data::SessionType::kKeepaliveAck, .nonce = data.nonce});
+                core::utility::assert_always(
+                    result != core::protocol::Serializer::SerializeResult::kInvalidArgument);
+            }
+            break;
+        default: return;
+        }
+    }
+
+    void error_callback() override {
+        // TODO: Report USB downlink deserialization errors through a dedicated error path.
+    }
+
+    void refresh_session_state() {
+        if (!session_established_)
+            return;
+
+        const uint64_t now = timer::Timer::timestamp64_quarter_us();
+        if (now - last_session_refresh_quarter_us_ < kSessionLeaseQuarterUs)
+            return;
+
+        deactivate_session();
+    }
 
     core::protocol::Deserializer deserializer_{*this};
 
@@ -180,6 +255,9 @@ private:
 
     const InterruptSafeBuffer::Batch* transmitting_batch_ = nullptr;
     size_t transmitted_size_ = 0;
+    bool session_established_ = false;
+    uint32_t current_session_nonce_ = 0;
+    uint64_t last_session_refresh_quarter_us_ = 0;
 };
 
 inline constinit Vendor::Lazy vendor;

--- a/host/src/protocol/handler.cpp
+++ b/host/src/protocol/handler.cpp
@@ -1,12 +1,20 @@
 #include "librmcs/protocol/handler.hpp"
 
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <exception>
 #include <memory>
+#include <mutex>
 #include <new>
+#include <random>
 #include <span>
+#include <stdexcept>
 #include <string_view>
+#include <thread>
 #include <utility>
 
 #include "core/src/protocol/deserializer.hpp"
@@ -23,38 +31,63 @@ namespace librmcs::host::protocol {
 
 class Handler::Impl : public core::protocol::DeserializeCallback {
 public:
+    static constexpr auto kSessionAckTimeout = std::chrono::milliseconds{200};
+    static constexpr size_t kSessionAckRetryCount = 5;
+    static constexpr auto kSessionRefreshInterval = std::chrono::milliseconds{250};
+
     explicit Impl(std::unique_ptr<transport::Transport> transport, data::DataCallback& callback)
-        : transport_(std::move(transport))
-        , callback_(callback)
-        , deserializer_(*this) {
+        : callback_(callback)
+        , deserializer_(*this)
+        , expected_session_nonce_(generate_session_nonce())
+        , transport_(std::move(transport)) {
         transport_->receive([this](std::span<const std::byte> buffer) {
             // Operating system automatically assembles the packet
             deserializer_.feed(buffer);
             deserializer_.finish_transfer();
         });
+
+        establish_session();
+        keepalive_thread_ = std::thread{[this] { keepalive_loop(); }};
+    }
+
+    ~Impl() override {
+        stop_keepalive_.store(true, std::memory_order_relaxed);
+        session_cv_.notify_all();
+        if (keepalive_thread_.joinable())
+            keepalive_thread_.join();
+
+        transport_.reset();
     }
 
     PacketBuilder start_transmit() { return PacketBuilder{transport_.get()}; }
 
     void can_deserialized_callback(
         core::protocol::FieldId id, const data::CanDataView& data) override {
+        if (!session_established())
+            return;
         if (!callback_.can_receive_callback(id, data))
             logging::get_logger().error("Unexpected can field id: ", static_cast<int>(id));
     }
 
     void uart_deserialized_callback(
         core::protocol::FieldId id, const data::UartDataView& data) override {
+        if (!session_established())
+            return;
         if (!callback_.uart_receive_callback(id, data))
             logging::get_logger().error("Unexpected uart field id: ", static_cast<int>(id));
     }
 
     void gpio_digital_data_deserialized_callback(
         uint8_t channel_index, const data::GpioDigitalDataView& data) override {
+        if (!session_established())
+            return;
         callback_.gpio_digital_read_result_callback(channel_index, data);
     }
 
     void gpio_analog_data_deserialized_callback(
         uint8_t channel_index, const data::GpioAnalogDataView& data) override {
+        if (!session_established())
+            return;
         callback_.gpio_analog_read_result_callback(channel_index, data);
     }
 
@@ -73,15 +106,45 @@ public:
     }
 
     void accelerometer_deserialized_callback(const data::AccelerometerDataView& data) override {
+        if (!session_established())
+            return;
         callback_.accelerometer_receive_callback(data);
     }
 
     void gyroscope_deserialized_callback(const data::GyroscopeDataView& data) override {
+        if (!session_established())
+            return;
         callback_.gyroscope_receive_callback(data);
     }
 
     void temperature_deserialized_callback(const data::TemperatureDataView& data) override {
+        if (!session_established())
+            return;
         callback_.temperature_receive_callback(data);
+    }
+
+    void session_control_deserialized_callback(const data::SessionControlView& data) override {
+        if (data.nonce != expected_session_nonce_)
+            return;
+
+        bool notify = false;
+        {
+            const std::scoped_lock guard{session_mutex_};
+            switch (data.type) {
+            case data::SessionType::kStartAck:
+                session_established_.store(true, std::memory_order_relaxed);
+                ++session_start_ack_count_;
+                notify = true;
+                break;
+            case data::SessionType::kKeepaliveAck:
+                ++session_keepalive_ack_count_;
+                notify = true;
+                break;
+            default: break;
+            }
+        }
+        if (notify)
+            session_cv_.notify_all();
     }
 
     void error_callback() override {
@@ -89,9 +152,114 @@ public:
     }
 
 private:
-    std::unique_ptr<transport::Transport> transport_;
+    [[nodiscard]] bool session_established() const {
+        return session_established_.load(std::memory_order_relaxed);
+    }
+
+    void establish_session() {
+        for (size_t attempt = 0; attempt < kSessionAckRetryCount; ++attempt) {
+            uint64_t previous_session_start_ack_count = 0;
+            {
+                const std::scoped_lock guard{session_mutex_};
+                previous_session_start_ack_count = session_start_ack_count_;
+            }
+
+            send_session_start();
+
+            std::unique_lock lock{session_mutex_};
+            if (session_cv_.wait_for(
+                    lock, kSessionAckTimeout, [this, previous_session_start_ack_count] {
+                        return session_start_ack_count_ > previous_session_start_ack_count;
+                    })) {
+                return;
+            }
+        }
+
+        throw std::runtime_error{"Timed out waiting for SESSION_ACK"};
+    }
+
+    void send_session_start() { send_session_control(data::SessionType::kStart, "Session Start"); }
+
+    void refresh_session() {
+        for (size_t attempt = 0; attempt < kSessionAckRetryCount; ++attempt) {
+            uint64_t previous_session_keepalive_ack_count = 0;
+            {
+                const std::scoped_lock guard{session_mutex_};
+                previous_session_keepalive_ack_count = session_keepalive_ack_count_;
+            }
+
+            send_session_keepalive();
+
+            std::unique_lock lock{session_mutex_};
+            if (session_cv_.wait_for(
+                    lock, kSessionAckTimeout, [this, previous_session_keepalive_ack_count] {
+                        return stop_keepalive_.load(std::memory_order_relaxed)
+                            || session_keepalive_ack_count_ > previous_session_keepalive_ack_count;
+                    })) {
+                return;
+            }
+        }
+
+        throw std::runtime_error{"Timed out waiting for SESSION_KEEPALIVE_ACK"};
+    }
+
+    void send_session_keepalive() {
+        send_session_control(data::SessionType::kKeepalive, "Session Keepalive");
+    }
+
+    void send_session_control(data::SessionType type, std::string_view operation_name) {
+        core::protocol::Serializer::SerializeResult result;
+        {
+            StreamBuffer buffer{*transport_};
+            core::protocol::Serializer serializer{buffer};
+            result =
+                serializer.write_session_control({.type = type, .nonce = expected_session_nonce_});
+        }
+
+        core::utility::assert_debug(
+            result != core::protocol::Serializer::SerializeResult::kInvalidArgument);
+        if (result == core::protocol::Serializer::SerializeResult::kBadAlloc) [[unlikely]]
+            throw std::runtime_error(
+                std::string{"Failed to transmit "} + std::string{operation_name}
+                + ": Transmit buffer unavailable (acquire failed)");
+    }
+
+    void keepalive_loop() {
+        while (!stop_keepalive_.load(std::memory_order_relaxed)) {
+            std::this_thread::sleep_for(kSessionRefreshInterval);
+            if (stop_keepalive_.load(std::memory_order_relaxed))
+                break;
+
+            try {
+                refresh_session();
+            } catch (const std::exception& exception) {
+                logging::get_logger().error(
+                    "Failed to refresh session: {}. Terminating...", exception.what());
+                std::terminate();
+            }
+        }
+    }
+
+    static uint32_t generate_session_nonce() {
+        std::random_device random_device;
+        std::uniform_int_distribution<uint32_t> distribution;
+        return distribution(random_device);
+    }
+
     data::DataCallback& callback_;
     core::protocol::Deserializer deserializer_;
+
+    mutable std::mutex session_mutex_;
+    std::condition_variable session_cv_;
+    std::atomic<bool> session_established_{false};
+    uint64_t session_start_ack_count_ = 0;
+    uint64_t session_keepalive_ack_count_ = 0;
+    uint32_t expected_session_nonce_ = 0;
+
+    std::unique_ptr<transport::Transport> transport_;
+
+    std::atomic<bool> stop_keepalive_{false};
+    std::thread keepalive_thread_;
 };
 
 namespace {

--- a/host/src/transport/usb/usb.cpp
+++ b/host/src/transport/usb/usb.cpp
@@ -1,5 +1,4 @@
 #include <atomic>
-#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <exception>
@@ -227,7 +226,8 @@ private:
                         wrapper->self_.usb_transmit_complete_callback(wrapper);
                     },
                     wrapper, 0);
-                transfer->flags = libusb_transfer_flags::LIBUSB_TRANSFER_FREE_BUFFER;
+                transfer->flags = libusb_transfer_flags::LIBUSB_TRANSFER_FREE_BUFFER
+                                | libusb_transfer_flags::LIBUSB_TRANSFER_ADD_ZERO_PACKET;
             }
         } catch (...) {
             for (auto& wrapper : transmit_transfers) {
@@ -294,11 +294,7 @@ private:
             return;
         }
 
-        const auto now = std::chrono::steady_clock::now();
-        const bool should_drop = now > last_rx_callback_timepoint_ + std::chrono::seconds{1};
-        last_rx_callback_timepoint_ = now;
-
-        if (!should_drop && transfer->actual_length > 0) {
+        if (transfer->actual_length > 0) {
             const auto* first = reinterpret_cast<std::byte*>(transfer->buffer);
             const auto size = static_cast<std::size_t>(transfer->actual_length);
             receive_callback_({first, size});
@@ -363,8 +359,6 @@ private:
     std::mutex transmit_transfer_pop_mutex_, transmit_transfer_push_mutex_;
 
     std::function<void(std::span<const std::byte>)> receive_callback_;
-    std::chrono::steady_clock::time_point last_rx_callback_timepoint_ =
-        std::chrono::steady_clock::time_point::min();
 };
 
 std::unique_ptr<Transport> create_transport(


### PR DESCRIPTION
Introduce a session control field for USB transport and require host and firmware traffic to be gated by an established session. The host now sends a nonce-based start request before exposing callbacks, then refreshes the session with periodic keepalive requests.

Firmware now acknowledges session start and keepalive requests, clears stale uplink data when a new session is activated, and drops downlink commands until the session is established. USB transfers also request a zero-length packet when needed so packet boundaries remain explicit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# USB 会话握手功能实现

## 概述

本 PR 实现了 USB 协议中的会话握手和生命周期管理机制，确保主机与固件的通信必须先建立会话才能进行。主要包括会话启动、确认、心跳保活等功能，以及会话过期自动清除等清理机制。

## 协议层变更（core 模块）

### 数据定义
- 在 `datas.hpp` 中新增 `DataId::kSession = 16` 枚举值
- 新增 `SessionType` 枚举，包含 `kStart`、`kStartAck`、`kKeepalive`、`kKeepaliveAck` 四种会话消息类型
- 新增 `SessionControlView` 结构体，包含 `type`（会话类型）和 `nonce`（32位随机数）两个字段

### 会话头定义
- 在 `protocol.hpp` 中新增 `SessionHeaderLayout` 和 `SessionHeader` 结构体，定义会话头的位字段布局

### 反序列化处理
- `Deserializer` 新增 `process_session_field()` 协程方法处理接收到的会话字段
- 读取并解析会话头的 `type` 和 `nonce` 信息
- 新增 `DeserializeCallback::session_control_deserialized_callback()` 虚函数用于会话消息回调

### 序列化支持
- `Serializer` 新增 `write_session_control()` 方法，用于序列化发送会话控制消息
- 新增 `required_session_size()` 计算会话字段所需字节数

## 固件层变更（firmware 模块）

### USB 中断缓冲区优化
- 调整 `InterruptSafeBuffer::allocate()` 和 `clear()` 的锁定逻辑
- `clear()` 方法现在显式获取锁并在完成后释放，确保原子性

### USB 会话管理（两个固件平台）
- TinyUSB 回调（`tud_suspend_cb`、`tud_umount_cb`）现在在断开连接时调用 `deactivate_session()` 和 `finish_downlink_transfer()` 进行清理
- 新增 `kSessionLease`（或 `kSessionLeaseQuarterUs`）常量定义会话租约超时时间

### 会话状态控制
- 新增私有成员变量：`session_established_`（会话是否已建立）、`current_session_nonce_`（当前会话随机数）、`last_session_refresh_`（最后一次会话刷新时间戳）
- 新增 `activate_session(nonce)` 方法：建立会话时清除过期缓冲数据并标记会话为已建立
- 新增 `deactivate_session()` 方法：禁用会话
- 新增 `refresh_session_state()` 方法：检测会话是否过期，过期时自动禁用
- `try_transmit()` 增加会话检查，仅在会话已建立时才允许发送数据

### 下行流量门控
- 所有反序列化回调（CAN、UART、GPIO 等）在处理前检查 `session_established_` 标志，未建立会话时直接返回
- 新增 `session_control_deserialized_callback()` 实现会话消息处理：
  - 收到 `kStart` 消息：验证 nonce，相同时刷新时间戳；不同时调用 `activate_session()` 并发送 `kStartAck`
  - 收到 `kKeepalive` 消息：验证 nonce 匹配且会话已建立时刷新时间戳并发送 `kKeepaliveAck`
- `error_callback()` 由原先的断言改为空实现

## 主机层变更（host 模块）

### 会话握手实现
- `Handler::Impl` 在初始化时通过 `establish_session()` 与固件进行会话协商，使用随机 nonce 进行握手
- 所有反序列化回调在会话未建立时直接返回，确保未建立会话不处理任何数据
- 新增 `session_control_deserialized_callback()` 处理固件回复的会话确认消息

### 心跳保活机制
- 独立线程 `keepalive_loop()` 周期性发送 `kKeepalive` 消息保持会话活跃
- `refresh_session()` 方法等待固件的心跳确认，如果确认超时则记录日志并终止程序

### 会话消息发送
- 新增 `send_session_control()` 方法使用 `Serializer` 生成会话控制包
- 新增 `generate_session_nonce()` 生成随机 nonce

### 会话状态管理
- 新增原子变量 `session_established_` 标记会话状态
- 新增 `expected_session_nonce_` 存储期望的 nonce
- 新增条件变量用于线程间同步（等待 ACK 响应）
- 析构时通过原子标志停止心跳线程并等待其退出

## USB 传输优化

- `host/src/transport/usb/usb.cpp` 中初始化发送传输时添加 `LIBUSB_TRANSFER_ADD_ZERO_PACKET` 标志，确保必要时请求零长度数据包以保证明确的包边界
- 移除基于时间的接收节流逻辑（原有的 `last_rx_callback_timepoint_` 成员被删除）
- 接收回调仅在收到实际数据（`actual_length > 0`）时才触发上层处理

## 总结

该 PR 通过引入会话握手机制和生命周期管理，确保了 USB 协议的通信安全性和可靠性。主机端在建立会话后才暴露回调并定期发送心跳，固件端在收到有效的会话启动消息后才处理下行命令，两端协同完成会话的建立、维护和自动过期检测，显著提升了协议的健壮性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->