### PR TITLE
refactor(host)!: Rename Agent API namespace to board

### DIFF
--- a/host/include/librmcs/board/c_board.hpp
+++ b/host/include/librmcs/board/c_board.hpp
@@ -4,16 +4,16 @@
 #include <stdexcept>
 #include <string_view>
 
-#include <librmcs/agent/common.hpp>
+#include <librmcs/board/common.hpp>
 #include <librmcs/data/datas.hpp>
 #include <librmcs/protocol/handler.hpp>
 #include <librmcs/spec/c_board/gpio.hpp>
 #include <librmcs/spec/gpio.hpp>
 
-namespace librmcs::agent {
+namespace librmcs::board {
 
 /**
- * @brief High-level host agent for C Board.
+ * @brief High-level host board interface for C Board.
  *
  * This class owns the transport and protocol stack for a single board connection.
  * The supplied `Callback` is stored by reference, is not owned by the board, and must outlive the
@@ -177,4 +177,4 @@ private:
     host::protocol::Handler handler_;
 };
 
-} // namespace librmcs::agent
+} // namespace librmcs::board

--- a/host/include/librmcs/board/common.hpp
+++ b/host/include/librmcs/board/common.hpp
@@ -4,17 +4,17 @@
 #include <type_traits>
 #include <utility>
 
-namespace librmcs::agent {
+namespace librmcs::board {
 
 /**
- * @brief Advanced transport options passed during agent construction.
+ * @brief Advanced transport options passed during board construction.
  *
  * `bind_advanced_options()` returns an object derived from `AdvancedOptions` whose `thread_setup`
  * callback depends on state stored in that derived object. Copying or moving the base type would
  * slice away that state while retaining a now-dangling function pointer, so `AdvancedOptions` is
  * intentionally non-copyable and non-movable.
  *
- * Construct `AdvancedOptions` directly during agent construction, or explicitly copy the required
+ * Construct `AdvancedOptions` directly during board construction, or explicitly copy the required
  * plain data fields into a fresh `AdvancedOptions` instance instead of copying an existing object.
  *
  * @warning Never copy, assign, or reuse any function pointer from an object returned by
@@ -87,4 +87,4 @@ auto bind_advanced_options(FunctorT&& thread_setup_impl) {
     return OptionsImpl{std::forward<FunctorT>(thread_setup_impl)};
 }
 
-} // namespace librmcs::agent
+} // namespace librmcs::board

--- a/host/include/librmcs/board/rmcs_board_lite.hpp
+++ b/host/include/librmcs/board/rmcs_board_lite.hpp
@@ -4,16 +4,16 @@
 #include <stdexcept>
 #include <string_view>
 
-#include <librmcs/agent/common.hpp>
+#include <librmcs/board/common.hpp>
 #include <librmcs/data/datas.hpp>
 #include <librmcs/protocol/handler.hpp>
 #include <librmcs/spec/gpio.hpp>
-#include <librmcs/spec/rmcs_board_pro/gpio.hpp>
+#include <librmcs/spec/rmcs_board_lite/gpio.hpp>
 
-namespace librmcs::agent {
+namespace librmcs::board {
 
 /**
- * @brief High-level host agent for RMCS Board Pro.
+ * @brief High-level host board interface for RMCS Board Lite.
  *
  * This class owns the transport and protocol stack for a single board connection.
  * The supplied `Callback` is stored by reference, is not owned by the board, and must outlive the
@@ -31,7 +31,7 @@ namespace librmcs::agent {
  * finished construction. Delay board construction with `std::optional` or `std::unique_ptr` when
  * callback behavior depends on such state.
  */
-class RmcsBoardPro final {
+class RmcsBoardLite final {
 public:
     class Callback : public data::DataCallback {
     public:
@@ -43,17 +43,15 @@ public:
         virtual void dbus_receive_callback(const librmcs::data::UartDataView& data) { (void)data; }
         virtual void uart0_receive_callback(const librmcs::data::UartDataView& data) { (void)data; }
         virtual void uart1_receive_callback(const librmcs::data::UartDataView& data) { (void)data; }
-        virtual void uart2_receive_callback(const librmcs::data::UartDataView& data) { (void)data; }
-        virtual void uart3_receive_callback(const librmcs::data::UartDataView& data) { (void)data; }
 
         virtual void gpio_digital_read_result_callback(
-            const librmcs::spec::rmcs_board_pro::GpioDescriptor& gpio,
+            const librmcs::spec::rmcs_board_lite::GpioDescriptor& gpio,
             const librmcs::data::GpioDigitalDataView& data) {
             (void)gpio;
             (void)data;
         }
         virtual void gpio_analog_read_result_callback(
-            const librmcs::spec::rmcs_board_pro::GpioDescriptor& gpio,
+            const librmcs::spec::rmcs_board_lite::GpioDescriptor& gpio,
             const librmcs::data::GpioAnalogDataView& data) {
             (void)gpio;
             (void)data;
@@ -86,44 +84,42 @@ public:
             case data::DataId::kUartDbus: dbus_receive_callback(data); return true;
             case data::DataId::kUart0: uart0_receive_callback(data); return true;
             case data::DataId::kUart1: uart1_receive_callback(data); return true;
-            case data::DataId::kUart2: uart2_receive_callback(data); return true;
-            case data::DataId::kUart3: uart3_receive_callback(data); return true;
             default: return false;
             }
         }
 
         bool gpio_digital_read_result_callback(
             uint8_t channel_index, const data::GpioDigitalDataView& data) final {
-            if (channel_index >= spec::rmcs_board_pro::kGpioDescriptors.size()) [[unlikely]]
+            if (channel_index >= spec::rmcs_board_lite::kGpioDescriptors.size()) [[unlikely]]
                 return false;
             gpio_digital_read_result_callback(
-                spec::rmcs_board_pro::kGpioDescriptors[channel_index], data);
+                spec::rmcs_board_lite::kGpioDescriptors[channel_index], data);
             return true;
         }
 
         bool gpio_analog_read_result_callback(
             uint8_t channel_index, const data::GpioAnalogDataView& data) final {
-            if (channel_index >= spec::rmcs_board_pro::kGpioDescriptors.size()) [[unlikely]]
+            if (channel_index >= spec::rmcs_board_lite::kGpioDescriptors.size()) [[unlikely]]
                 return false;
             gpio_analog_read_result_callback(
-                spec::rmcs_board_pro::kGpioDescriptors[channel_index], data);
+                spec::rmcs_board_lite::kGpioDescriptors[channel_index], data);
             return true;
         }
     };
 
-    explicit RmcsBoardPro(
+    explicit RmcsBoardLite(
         Callback& callback = default_callback_, std::string_view serial_filter = {},
         const AdvancedOptions& options = {})
-        : handler_(0xA11C, 0xAF01, serial_filter, options, callback) {}
+        : handler_(0xA11C, 0xA801, serial_filter, options, callback) {}
 
-    RmcsBoardPro(const RmcsBoardPro&) = delete;
-    RmcsBoardPro& operator=(const RmcsBoardPro&) = delete;
-    RmcsBoardPro(RmcsBoardPro&&) = delete;
-    RmcsBoardPro& operator=(RmcsBoardPro&&) = delete;
-    ~RmcsBoardPro() = default;
+    RmcsBoardLite(const RmcsBoardLite&) = delete;
+    RmcsBoardLite& operator=(const RmcsBoardLite&) = delete;
+    RmcsBoardLite(RmcsBoardLite&&) = delete;
+    RmcsBoardLite& operator=(RmcsBoardLite&&) = delete;
+    ~RmcsBoardLite() = default;
 
     class PacketBuilder {
-        friend class RmcsBoardPro;
+        friend class RmcsBoardLite;
 
     public:
         PacketBuilder& can0_transmit(const librmcs::data::CanDataView& data) {
@@ -157,19 +153,9 @@ public:
                 throw std::invalid_argument{"UART1 transmission failed: Invalid UART data"};
             return *this;
         }
-        PacketBuilder& uart2_transmit(const librmcs::data::UartDataView& data) {
-            if (!builder_.write_uart(data::DataId::kUart2, data)) [[unlikely]]
-                throw std::invalid_argument{"UART2 transmission failed: Invalid UART data"};
-            return *this;
-        }
-        PacketBuilder& uart3_transmit(const librmcs::data::UartDataView& data) {
-            if (!builder_.write_uart(data::DataId::kUart3, data)) [[unlikely]]
-                throw std::invalid_argument{"UART3 transmission failed: Invalid UART data"};
-            return *this;
-        }
 
         PacketBuilder& gpio_digital_write(
-            const librmcs::spec::rmcs_board_pro::GpioDescriptor& gpio,
+            const librmcs::spec::rmcs_board_lite::GpioDescriptor& gpio,
             const librmcs::data::GpioDigitalDataView& data) {
             if (!gpio.supports(spec::GpioCapability::kDigitalWrite)
                 || !builder_.write_gpio_digital_data(gpio.channel_index, data)) [[unlikely]]
@@ -177,7 +163,7 @@ public:
             return *this;
         }
         PacketBuilder& gpio_digital_read(
-            const librmcs::spec::rmcs_board_pro::GpioDescriptor& gpio,
+            const librmcs::spec::rmcs_board_lite::GpioDescriptor& gpio,
             const librmcs::data::GpioReadConfigView& data) {
             if (!data.supported(gpio)
                 || !builder_.write_gpio_digital_read_config(gpio.channel_index, data)) [[unlikely]]
@@ -186,7 +172,7 @@ public:
             return *this;
         }
         PacketBuilder& gpio_analog_write(
-            const librmcs::spec::rmcs_board_pro::GpioDescriptor& gpio,
+            const librmcs::spec::rmcs_board_lite::GpioDescriptor& gpio,
             const librmcs::data::GpioAnalogDataView& data) {
             if (!gpio.supports(spec::GpioCapability::kAnalogWrite)
                 || !builder_.write_gpio_analog_data(gpio.channel_index, data)) [[unlikely]]
@@ -207,4 +193,4 @@ private:
     host::protocol::Handler handler_;
 };
 
-} // namespace librmcs::agent
+} // namespace librmcs::board

--- a/host/include/librmcs/board/rmcs_board_pro.hpp
+++ b/host/include/librmcs/board/rmcs_board_pro.hpp
@@ -4,16 +4,16 @@
 #include <stdexcept>
 #include <string_view>
 
-#include <librmcs/agent/common.hpp>
+#include <librmcs/board/common.hpp>
 #include <librmcs/data/datas.hpp>
 #include <librmcs/protocol/handler.hpp>
 #include <librmcs/spec/gpio.hpp>
-#include <librmcs/spec/rmcs_board_lite/gpio.hpp>
+#include <librmcs/spec/rmcs_board_pro/gpio.hpp>
 
-namespace librmcs::agent {
+namespace librmcs::board {
 
 /**
- * @brief High-level host agent for RMCS Board Lite.
+ * @brief High-level host board interface for RMCS Board Pro.
  *
  * This class owns the transport and protocol stack for a single board connection.
  * The supplied `Callback` is stored by reference, is not owned by the board, and must outlive the
@@ -31,7 +31,7 @@ namespace librmcs::agent {
  * finished construction. Delay board construction with `std::optional` or `std::unique_ptr` when
  * callback behavior depends on such state.
  */
-class RmcsBoardLite final {
+class RmcsBoardPro final {
 public:
     class Callback : public data::DataCallback {
     public:
@@ -43,15 +43,17 @@ public:
         virtual void dbus_receive_callback(const librmcs::data::UartDataView& data) { (void)data; }
         virtual void uart0_receive_callback(const librmcs::data::UartDataView& data) { (void)data; }
         virtual void uart1_receive_callback(const librmcs::data::UartDataView& data) { (void)data; }
+        virtual void uart2_receive_callback(const librmcs::data::UartDataView& data) { (void)data; }
+        virtual void uart3_receive_callback(const librmcs::data::UartDataView& data) { (void)data; }
 
         virtual void gpio_digital_read_result_callback(
-            const librmcs::spec::rmcs_board_lite::GpioDescriptor& gpio,
+            const librmcs::spec::rmcs_board_pro::GpioDescriptor& gpio,
             const librmcs::data::GpioDigitalDataView& data) {
             (void)gpio;
             (void)data;
         }
         virtual void gpio_analog_read_result_callback(
-            const librmcs::spec::rmcs_board_lite::GpioDescriptor& gpio,
+            const librmcs::spec::rmcs_board_pro::GpioDescriptor& gpio,
             const librmcs::data::GpioAnalogDataView& data) {
             (void)gpio;
             (void)data;
@@ -84,42 +86,44 @@ public:
             case data::DataId::kUartDbus: dbus_receive_callback(data); return true;
             case data::DataId::kUart0: uart0_receive_callback(data); return true;
             case data::DataId::kUart1: uart1_receive_callback(data); return true;
+            case data::DataId::kUart2: uart2_receive_callback(data); return true;
+            case data::DataId::kUart3: uart3_receive_callback(data); return true;
             default: return false;
             }
         }
 
         bool gpio_digital_read_result_callback(
             uint8_t channel_index, const data::GpioDigitalDataView& data) final {
-            if (channel_index >= spec::rmcs_board_lite::kGpioDescriptors.size()) [[unlikely]]
+            if (channel_index >= spec::rmcs_board_pro::kGpioDescriptors.size()) [[unlikely]]
                 return false;
             gpio_digital_read_result_callback(
-                spec::rmcs_board_lite::kGpioDescriptors[channel_index], data);
+                spec::rmcs_board_pro::kGpioDescriptors[channel_index], data);
             return true;
         }
 
         bool gpio_analog_read_result_callback(
             uint8_t channel_index, const data::GpioAnalogDataView& data) final {
-            if (channel_index >= spec::rmcs_board_lite::kGpioDescriptors.size()) [[unlikely]]
+            if (channel_index >= spec::rmcs_board_pro::kGpioDescriptors.size()) [[unlikely]]
                 return false;
             gpio_analog_read_result_callback(
-                spec::rmcs_board_lite::kGpioDescriptors[channel_index], data);
+                spec::rmcs_board_pro::kGpioDescriptors[channel_index], data);
             return true;
         }
     };
 
-    explicit RmcsBoardLite(
+    explicit RmcsBoardPro(
         Callback& callback = default_callback_, std::string_view serial_filter = {},
         const AdvancedOptions& options = {})
-        : handler_(0xA11C, 0xA801, serial_filter, options, callback) {}
+        : handler_(0xA11C, 0xAF01, serial_filter, options, callback) {}
 
-    RmcsBoardLite(const RmcsBoardLite&) = delete;
-    RmcsBoardLite& operator=(const RmcsBoardLite&) = delete;
-    RmcsBoardLite(RmcsBoardLite&&) = delete;
-    RmcsBoardLite& operator=(RmcsBoardLite&&) = delete;
-    ~RmcsBoardLite() = default;
+    RmcsBoardPro(const RmcsBoardPro&) = delete;
+    RmcsBoardPro& operator=(const RmcsBoardPro&) = delete;
+    RmcsBoardPro(RmcsBoardPro&&) = delete;
+    RmcsBoardPro& operator=(RmcsBoardPro&&) = delete;
+    ~RmcsBoardPro() = default;
 
     class PacketBuilder {
-        friend class RmcsBoardLite;
+        friend class RmcsBoardPro;
 
     public:
         PacketBuilder& can0_transmit(const librmcs::data::CanDataView& data) {
@@ -153,9 +157,19 @@ public:
                 throw std::invalid_argument{"UART1 transmission failed: Invalid UART data"};
             return *this;
         }
+        PacketBuilder& uart2_transmit(const librmcs::data::UartDataView& data) {
+            if (!builder_.write_uart(data::DataId::kUart2, data)) [[unlikely]]
+                throw std::invalid_argument{"UART2 transmission failed: Invalid UART data"};
+            return *this;
+        }
+        PacketBuilder& uart3_transmit(const librmcs::data::UartDataView& data) {
+            if (!builder_.write_uart(data::DataId::kUart3, data)) [[unlikely]]
+                throw std::invalid_argument{"UART3 transmission failed: Invalid UART data"};
+            return *this;
+        }
 
         PacketBuilder& gpio_digital_write(
-            const librmcs::spec::rmcs_board_lite::GpioDescriptor& gpio,
+            const librmcs::spec::rmcs_board_pro::GpioDescriptor& gpio,
             const librmcs::data::GpioDigitalDataView& data) {
             if (!gpio.supports(spec::GpioCapability::kDigitalWrite)
                 || !builder_.write_gpio_digital_data(gpio.channel_index, data)) [[unlikely]]
@@ -163,7 +177,7 @@ public:
             return *this;
         }
         PacketBuilder& gpio_digital_read(
-            const librmcs::spec::rmcs_board_lite::GpioDescriptor& gpio,
+            const librmcs::spec::rmcs_board_pro::GpioDescriptor& gpio,
             const librmcs::data::GpioReadConfigView& data) {
             if (!data.supported(gpio)
                 || !builder_.write_gpio_digital_read_config(gpio.channel_index, data)) [[unlikely]]
@@ -172,7 +186,7 @@ public:
             return *this;
         }
         PacketBuilder& gpio_analog_write(
-            const librmcs::spec::rmcs_board_lite::GpioDescriptor& gpio,
+            const librmcs::spec::rmcs_board_pro::GpioDescriptor& gpio,
             const librmcs::data::GpioAnalogDataView& data) {
             if (!gpio.supports(spec::GpioCapability::kAnalogWrite)
                 || !builder_.write_gpio_analog_data(gpio.channel_index, data)) [[unlikely]]
@@ -193,4 +207,4 @@ private:
     host::protocol::Handler handler_;
 };
 
-} // namespace librmcs::agent
+} // namespace librmcs::board

--- a/host/include/librmcs/protocol/handler.hpp
+++ b/host/include/librmcs/protocol/handler.hpp
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <string_view>
 
-#include <librmcs/agent/common.hpp>
+#include <librmcs/board/common.hpp>
 #include <librmcs/data/datas.hpp>
 #include <librmcs/export.hpp>
 
@@ -43,7 +43,7 @@ public:
 
     Handler(
         uint16_t usb_vid, int32_t usb_pid, std::string_view serial_filter,
-        const agent::AdvancedOptions& options, data::DataCallback& callback);
+        const board::AdvancedOptions& options, data::DataCallback& callback);
 
     Handler(const Handler&) = delete;
     Handler& operator=(const Handler&) = delete;

--- a/host/src/protocol/handler.cpp
+++ b/host/src/protocol/handler.cpp
@@ -24,7 +24,7 @@
 #include "host/src/logging/logging.hpp"
 #include "host/src/protocol/stream_buffer.hpp"
 #include "host/src/transport/transport.hpp"
-#include "librmcs/agent/common.hpp"
+#include "librmcs/board/common.hpp"
 #include "librmcs/data/datas.hpp"
 
 namespace librmcs::host::protocol {
@@ -379,7 +379,7 @@ bool Handler::PacketBuilder::write_gpio_analog_data(
 
 Handler::Handler(
     uint16_t usb_vid, int32_t usb_pid, std::string_view serial_filter,
-    const agent::AdvancedOptions& options, data::DataCallback& callback)
+    const board::AdvancedOptions& options, data::DataCallback& callback)
     : impl_(new Impl(
           transport::usb::create_transport(usb_vid, usb_pid, serial_filter, options), callback)) {}
 

--- a/host/src/transport/transport.hpp
+++ b/host/src/transport/transport.hpp
@@ -8,7 +8,7 @@
 #include <string_view>
 
 #include "core/src/protocol/constant.hpp"
-#include "librmcs/agent/common.hpp"
+#include "librmcs/board/common.hpp"
 
 namespace librmcs::host::transport {
 
@@ -141,7 +141,7 @@ public:
 
 namespace usb {
 
-using ConnectionOptions = agent::AdvancedOptions;
+using ConnectionOptions = board::AdvancedOptions;
 
 std::unique_ptr<Transport> create_transport(
     uint16_t usb_vid, int32_t usb_pid, std::string_view serial_filter,


### PR DESCRIPTION
- Move public SDK headers from librmcs/agent to librmcs/board
- Rename librmcs::agent to librmcs::board across host code
- Update internal includes to use the new board API

BREAKING CHANGE: Public host SDK includes and namespace references now use board instead of agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 摘要

该拉取请求将主机代码库中的Agent API命名空间重命名为Board，包括移动公开SDK头文件位置和更新所有相关的命名空间引用。这是一个影响公开主机SDK接口和命名空间的破坏性变更。

## 受影响的主要文件

### 公开SDK头文件迁移
- **host/include/librmcs/board/c_board.hpp**：`CBoard`类从`librmcs::agent`命名空间迁移至`librmcs::board`，同时更新头文件包含从`librmcs/agent/common.hpp`改为`librmcs/board/common.hpp`

- **host/include/librmcs/board/common.hpp**：`AdvancedOptions`结构体和`bind_advanced_options()`模板函数从`librmcs::agent`迁移至`librmcs::board`命名空间

- **host/include/librmcs/board/rmcs_board_lite.hpp**：`RmcsBoardLite`类及其嵌套类型（`Callback`、`PacketBuilder`）从`librmcs::agent`迁移至`librmcs::board`命名空间

- **host/include/librmcs/board/rmcs_board_pro.hpp**：`RmcsBoardPro`类从`librmcs::agent`迁移至`librmcs::board`命名空间

### 内部实现文件更新
- **host/include/librmcs/protocol/handler.hpp**：`Handler`构造函数参数类型从`const agent::AdvancedOptions&`更改为`const board::AdvancedOptions&`

- **host/src/protocol/handler.cpp**：同步更新构造函数实现中的`AdvancedOptions`参数引用

- **host/src/transport/transport.hpp**：类型别名`ConnectionOptions`从`agent::AdvancedOptions`改为`board::AdvancedOptions`

## 破坏性变更

所有引用以下类型或命名空间的客户端代码需要进行更新：
- `librmcs::agent::CBoard` → `librmcs::board::CBoard`
- `librmcs::agent::AdvancedOptions` → `librmcs::board::AdvancedOptions`
- `librmcs::agent::RmcsBoardLite` → `librmcs::board::RmcsBoardLite`
- `librmcs::agent::RmcsBoardPro` → `librmcs::board::RmcsBoardPro`
- 所有使用`agent::AdvancedOptions`作为函数参数的代码需要更新为`board::AdvancedOptions`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->