### PR TITLE
fix(protocol): Fail invalid routes and simplify GPIO payloads

### DIFF
--- a/core/src/protocol/deserializer.cpp
+++ b/core/src/protocol/deserializer.cpp
@@ -108,9 +108,7 @@ coroutine::LifoTask<bool> Deserializer::process_can_field(FieldId field_id) {
         data_view.can_data = std::span<const std::byte>{};
     }
 
-    callback_.can_deserialized_callback(field_id, data_view);
-
-    co_return true;
+    co_return callback_.can_deserialized_callback(field_id, data_view);
 }
 
 coroutine::LifoTask<bool> Deserializer::process_uart_field(FieldId field_id) {
@@ -147,9 +145,7 @@ coroutine::LifoTask<bool> Deserializer::process_uart_field(FieldId field_id) {
         data_view.uart_data = std::span<const std::byte>{};
     }
 
-    callback_.uart_deserialized_callback(field_id, data_view);
-
-    co_return true;
+    co_return callback_.uart_deserialized_callback(field_id, data_view);
 }
 
 coroutine::LifoTask<bool> Deserializer::process_gpio_field(FieldId) {
@@ -169,16 +165,25 @@ coroutine::LifoTask<bool> Deserializer::process_gpio_field(FieldId) {
     }
 
     switch (payload_type) {
-    case GpioHeader::PayloadEnum::kDigitalWriteLow:
-    case GpioHeader::PayloadEnum::kDigitalWriteHigh: {
-        if (timestamped) [[unlikely]]
-            co_return false;
+    case GpioHeader::PayloadEnum::kDigitalLow:
+    case GpioHeader::PayloadEnum::kDigitalHigh: {
         data::GpioDigitalDataView data_view{};
-        data_view.high = payload_type == GpioHeader::PayloadEnum::kDigitalWriteHigh;
-        callback_.gpio_digital_data_deserialized_callback(channel_index, data_view);
+        data_view.high = payload_type == GpioHeader::PayloadEnum::kDigitalHigh;
+        if (timestamped) {
+            const auto* payload_bytes =
+                co_await peek_bytes(sizeof(GpioDigitalReadTimestampPayload));
+            if (!payload_bytes) [[unlikely]]
+                co_return false;
+            auto payload = GpioDigitalReadTimestampPayload::CRef{payload_bytes};
+            data_view.timestamp_quarter_us =
+                payload.get<GpioDigitalReadTimestampPayload::TimestampQuarterUs>();
+            consume_peeked();
+        }
+        if (!callback_.gpio_digital_data_deserialized_callback(channel_index, data_view))
+            co_return false;
         break;
     }
-    case GpioHeader::PayloadEnum::kAnalogWrite: {
+    case GpioHeader::PayloadEnum::kAnalog: {
         if (timestamped) [[unlikely]]
             co_return false;
         const auto* payload_bytes = co_await peek_bytes(sizeof(GpioAnalogPayload));
@@ -190,11 +195,12 @@ coroutine::LifoTask<bool> Deserializer::process_gpio_field(FieldId) {
         data_view.value = payload.get<GpioAnalogPayload::Value>();
         consume_peeked();
 
-        callback_.gpio_analog_data_deserialized_callback(channel_index, data_view);
+        if (!callback_.gpio_analog_data_deserialized_callback(channel_index, data_view))
+            co_return false;
         break;
     }
-    case GpioHeader::PayloadEnum::kDigitalRead:
-    case GpioHeader::PayloadEnum::kAnalogRead: {
+    case GpioHeader::PayloadEnum::kDigitalReadConfig:
+    case GpioHeader::PayloadEnum::kAnalogReadConfig: {
         const auto* payload_bytes = co_await peek_bytes(sizeof(GpioReadConfigPayload));
         if (!payload_bytes) [[unlikely]]
             co_return false;
@@ -213,45 +219,15 @@ coroutine::LifoTask<bool> Deserializer::process_gpio_field(FieldId) {
             && data_view.pull != data::GpioPull::kDown)
             co_return false;
 
-        if (payload_type == GpioHeader::PayloadEnum::kDigitalRead) {
-            callback_.gpio_digital_read_config_deserialized_callback(channel_index, data_view);
+        if (payload_type == GpioHeader::PayloadEnum::kDigitalReadConfig) {
+            if (!callback_.gpio_digital_read_config_deserialized_callback(channel_index, data_view))
+                co_return false;
         } else {
             if (data_view.capture_timestamp || data_view.rising_edge || data_view.falling_edge)
                 co_return false;
-            callback_.gpio_analog_read_config_deserialized_callback(channel_index, data_view);
-        }
-        break;
-    }
-    case GpioHeader::PayloadEnum::kDigitalReadResultLow:
-    case GpioHeader::PayloadEnum::kDigitalReadResultHigh: {
-        data::GpioDigitalDataView data_view{};
-        data_view.high = payload_type == GpioHeader::PayloadEnum::kDigitalReadResultHigh;
-        if (timestamped) {
-            const auto* payload_bytes =
-                co_await peek_bytes(sizeof(GpioDigitalReadTimestampPayload));
-            if (!payload_bytes) [[unlikely]]
+            if (!callback_.gpio_analog_read_config_deserialized_callback(channel_index, data_view))
                 co_return false;
-            auto payload = GpioDigitalReadTimestampPayload::CRef{payload_bytes};
-            data_view.timestamp_quarter_us =
-                payload.get<GpioDigitalReadTimestampPayload::TimestampQuarterUs>();
-            consume_peeked();
         }
-        callback_.gpio_digital_data_deserialized_callback(channel_index, data_view);
-        break;
-    }
-    case GpioHeader::PayloadEnum::kAnalogReadResult: {
-        if (timestamped) [[unlikely]]
-            co_return false;
-        const auto* payload_bytes = co_await peek_bytes(sizeof(GpioAnalogPayload));
-        if (!payload_bytes) [[unlikely]]
-            co_return false;
-
-        auto payload = GpioAnalogPayload::CRef{payload_bytes};
-        data::GpioAnalogDataView data_view{};
-        data_view.value = payload.get<GpioAnalogPayload::Value>();
-        consume_peeked();
-
-        callback_.gpio_analog_data_deserialized_callback(channel_index, data_view);
         break;
     }
     default: co_return false;

--- a/core/src/protocol/deserializer.hpp
+++ b/core/src/protocol/deserializer.hpp
@@ -24,20 +24,22 @@ public:
     DeserializeCallback& operator=(DeserializeCallback&&) = delete;
     virtual ~DeserializeCallback() = default;
 
-    virtual void can_deserialized_callback(FieldId id, const data::CanDataView& data) = 0;
+    [[nodiscard]] virtual bool
+        can_deserialized_callback(FieldId id, const data::CanDataView& data) = 0;
 
-    virtual void uart_deserialized_callback(FieldId id, const data::UartDataView& data) = 0;
+    [[nodiscard]] virtual bool
+        uart_deserialized_callback(FieldId id, const data::UartDataView& data) = 0;
 
-    virtual void gpio_digital_data_deserialized_callback(
+    [[nodiscard]] virtual bool gpio_digital_data_deserialized_callback(
         uint8_t channel_index, const data::GpioDigitalDataView& data) = 0;
 
-    virtual void gpio_analog_data_deserialized_callback(
+    [[nodiscard]] virtual bool gpio_analog_data_deserialized_callback(
         uint8_t channel_index, const data::GpioAnalogDataView& data) = 0;
 
-    virtual void gpio_digital_read_config_deserialized_callback(
+    [[nodiscard]] virtual bool gpio_digital_read_config_deserialized_callback(
         uint8_t channel_index, const data::GpioReadConfigView& data) = 0;
 
-    virtual void gpio_analog_read_config_deserialized_callback(
+    [[nodiscard]] virtual bool gpio_analog_read_config_deserialized_callback(
         uint8_t channel_index, const data::GpioReadConfigView& data) = 0;
 
     virtual void accelerometer_deserialized_callback(const data::AccelerometerDataView& data) = 0;

--- a/core/src/protocol/protocol.hpp
+++ b/core/src/protocol/protocol.hpp
@@ -93,14 +93,11 @@ struct SessionHeader
 
 struct GpioHeader : utility::Bitfield<2> {
     enum class PayloadEnum : uint8_t {
-        kDigitalWriteLow = 0b0000,
-        kDigitalWriteHigh = 0b0001,
-        kAnalogWrite = 0b0010,
-        kDigitalRead = 0b0100,
-        kAnalogRead = 0b0110,
-        kDigitalReadResultLow = 0b1000,
-        kDigitalReadResultHigh = 0b1001,
-        kAnalogReadResult = 0b1010,
+        kDigitalLow = 0b0000,
+        kDigitalHigh = 0b0001,
+        kAnalog = 0b0010,
+        kDigitalReadConfig = 0b0100,
+        kAnalogReadConfig = 0b0110,
     };
 
     using PayloadType = utility::BitfieldMember<4, 4, PayloadEnum>;

--- a/core/src/protocol/serializer.hpp
+++ b/core/src/protocol/serializer.hpp
@@ -120,134 +120,11 @@ public:
         return SerializeResult::kSuccess;
     }
 
-    SerializeResult write_gpio_digital_data(
+    SerializeResult write_gpio_digital_value(
         uint8_t channel_index, const data::GpioDigitalDataView& view) noexcept {
         utility::assert_debug(channel_index < (1U << GpioHeader::ChannelIndex::kBitWidth));
-        LIBRMCS_VERIFY_LIKELY(
-            !view.timestamp_quarter_us.has_value(), SerializeResult::kInvalidArgument);
-        const auto payload_type = view.high ? GpioHeader::PayloadEnum::kDigitalWriteHigh
-                                            : GpioHeader::PayloadEnum::kDigitalWriteLow;
-        const std::size_t required = required_gpio_size(FieldId::kGpio, payload_type);
-        LIBRMCS_VERIFY_LIKELY(required, SerializeResult::kInvalidArgument);
-
-        auto dst = buffer_.allocate(required);
-        LIBRMCS_VERIFY_LIKELY(!dst.empty(), SerializeResult::kBadAlloc);
-        utility::assert_debug(dst.size() == required);
-        std::byte* cursor = dst.data();
-
-        write_field_header(cursor, FieldId::kGpio);
-
-        auto header = GpioHeader::Ref(cursor);
-        cursor += sizeof(GpioHeader);
-        header.set<GpioHeader::PayloadType>(payload_type);
-        header.set<GpioHeader::ChannelIndex>(channel_index);
-        header.set<GpioHeader::Timestamped>(false);
-
-        utility::assert_debug(cursor == dst.data() + dst.size());
-        return SerializeResult::kSuccess;
-    }
-
-    SerializeResult write_gpio_digital_read_config(
-        uint8_t channel_index, const data::GpioReadConfigView& view) noexcept {
-        utility::assert_debug(channel_index < (1U << GpioHeader::ChannelIndex::kBitWidth));
-        const std::size_t required =
-            required_gpio_size(FieldId::kGpio, GpioHeader::PayloadEnum::kDigitalRead);
-        LIBRMCS_VERIFY_LIKELY(required, SerializeResult::kInvalidArgument);
-
-        auto dst = buffer_.allocate(required);
-        LIBRMCS_VERIFY_LIKELY(!dst.empty(), SerializeResult::kBadAlloc);
-        utility::assert_debug(dst.size() == required);
-        std::byte* cursor = dst.data();
-
-        write_field_header(cursor, FieldId::kGpio);
-
-        auto header = GpioHeader::Ref(cursor);
-        cursor += sizeof(GpioHeader);
-        header.set<GpioHeader::PayloadType>(GpioHeader::PayloadEnum::kDigitalRead);
-        header.set<GpioHeader::ChannelIndex>(channel_index);
-        header.set<GpioHeader::Timestamped>(view.capture_timestamp);
-
-        auto payload = GpioReadConfigPayload::Ref(cursor);
-        cursor += sizeof(GpioReadConfigPayload);
-        payload.set<GpioReadConfigPayload::Asap>(view.asap);
-        payload.set<GpioReadConfigPayload::RisingEdge>(view.rising_edge);
-        payload.set<GpioReadConfigPayload::FallingEdge>(view.falling_edge);
-        payload.set<GpioReadConfigPayload::Pull>(view.pull);
-        payload.set<GpioReadConfigPayload::PeriodMs>(view.period_ms);
-
-        utility::assert_debug(cursor == dst.data() + dst.size());
-        return SerializeResult::kSuccess;
-    }
-
-    SerializeResult write_gpio_analog_data(
-        uint8_t channel_index, const data::GpioAnalogDataView& view) noexcept {
-        utility::assert_debug(channel_index < (1U << GpioHeader::ChannelIndex::kBitWidth));
-        const std::size_t required =
-            required_gpio_size(FieldId::kGpio, GpioHeader::PayloadEnum::kAnalogWrite);
-        LIBRMCS_VERIFY_LIKELY(required, SerializeResult::kInvalidArgument);
-
-        auto dst = buffer_.allocate(required);
-        LIBRMCS_VERIFY_LIKELY(!dst.empty(), SerializeResult::kBadAlloc);
-        utility::assert_debug(dst.size() == required);
-        std::byte* cursor = dst.data();
-
-        write_field_header(cursor, FieldId::kGpio);
-
-        auto header = GpioHeader::Ref(cursor);
-        cursor += sizeof(GpioHeader);
-        header.set<GpioHeader::PayloadType>(GpioHeader::PayloadEnum::kAnalogWrite);
-        header.set<GpioHeader::ChannelIndex>(channel_index);
-        header.set<GpioHeader::Timestamped>(false);
-
-        auto payload = GpioAnalogPayload::Ref(cursor);
-        cursor += sizeof(GpioAnalogPayload);
-        payload.set<GpioAnalogPayload::Value>(view.value);
-
-        utility::assert_debug(cursor == dst.data() + dst.size());
-        return SerializeResult::kSuccess;
-    }
-
-    SerializeResult write_gpio_analog_read_config(
-        uint8_t channel_index, const data::GpioReadConfigView& view) noexcept {
-        utility::assert_debug(channel_index < (1U << GpioHeader::ChannelIndex::kBitWidth));
-        LIBRMCS_VERIFY_LIKELY(
-            !view.falling_edge && !view.rising_edge, SerializeResult::kInvalidArgument);
-        LIBRMCS_VERIFY_LIKELY(!view.capture_timestamp, SerializeResult::kInvalidArgument);
-
-        const std::size_t required =
-            required_gpio_size(FieldId::kGpio, GpioHeader::PayloadEnum::kAnalogRead);
-        LIBRMCS_VERIFY_LIKELY(required, SerializeResult::kInvalidArgument);
-
-        auto dst = buffer_.allocate(required);
-        LIBRMCS_VERIFY_LIKELY(!dst.empty(), SerializeResult::kBadAlloc);
-        utility::assert_debug(dst.size() == required);
-        std::byte* cursor = dst.data();
-
-        write_field_header(cursor, FieldId::kGpio);
-
-        auto header = GpioHeader::Ref(cursor);
-        cursor += sizeof(GpioHeader);
-        header.set<GpioHeader::PayloadType>(GpioHeader::PayloadEnum::kAnalogRead);
-        header.set<GpioHeader::ChannelIndex>(channel_index);
-        header.set<GpioHeader::Timestamped>(false);
-
-        auto payload = GpioReadConfigPayload::Ref(cursor);
-        cursor += sizeof(GpioReadConfigPayload);
-        payload.set<GpioReadConfigPayload::Asap>(view.asap);
-        payload.set<GpioReadConfigPayload::RisingEdge>(false);
-        payload.set<GpioReadConfigPayload::FallingEdge>(false);
-        payload.set<GpioReadConfigPayload::Pull>(view.pull);
-        payload.set<GpioReadConfigPayload::PeriodMs>(view.period_ms);
-
-        utility::assert_debug(cursor == dst.data() + dst.size());
-        return SerializeResult::kSuccess;
-    }
-
-    SerializeResult write_gpio_digital_read_result(
-        uint8_t channel_index, const data::GpioDigitalDataView& view) noexcept {
-        utility::assert_debug(channel_index < (1U << GpioHeader::ChannelIndex::kBitWidth));
-        const auto payload_type = view.high ? GpioHeader::PayloadEnum::kDigitalReadResultHigh
-                                            : GpioHeader::PayloadEnum::kDigitalReadResultLow;
+        const auto payload_type = view.high ? GpioHeader::PayloadEnum::kDigitalHigh
+                                            : GpioHeader::PayloadEnum::kDigitalLow;
         const std::size_t required =
             required_gpio_size(FieldId::kGpio, payload_type, view.timestamp_quarter_us.has_value());
         LIBRMCS_VERIFY_LIKELY(required, SerializeResult::kInvalidArgument);
@@ -276,11 +153,11 @@ public:
         return SerializeResult::kSuccess;
     }
 
-    SerializeResult write_gpio_analog_read_result(
-        uint8_t channel_index, const data::GpioAnalogDataView& view) noexcept {
+    SerializeResult write_gpio_digital_read_config(
+        uint8_t channel_index, const data::GpioReadConfigView& view) noexcept {
         utility::assert_debug(channel_index < (1U << GpioHeader::ChannelIndex::kBitWidth));
         const std::size_t required =
-            required_gpio_size(FieldId::kGpio, GpioHeader::PayloadEnum::kAnalogReadResult);
+            required_gpio_size(FieldId::kGpio, GpioHeader::PayloadEnum::kDigitalReadConfig);
         LIBRMCS_VERIFY_LIKELY(required, SerializeResult::kInvalidArgument);
 
         auto dst = buffer_.allocate(required);
@@ -292,13 +169,81 @@ public:
 
         auto header = GpioHeader::Ref(cursor);
         cursor += sizeof(GpioHeader);
-        header.set<GpioHeader::PayloadType>(GpioHeader::PayloadEnum::kAnalogReadResult);
+        header.set<GpioHeader::PayloadType>(GpioHeader::PayloadEnum::kDigitalReadConfig);
+        header.set<GpioHeader::ChannelIndex>(channel_index);
+        header.set<GpioHeader::Timestamped>(view.capture_timestamp);
+
+        auto payload = GpioReadConfigPayload::Ref(cursor);
+        cursor += sizeof(GpioReadConfigPayload);
+        payload.set<GpioReadConfigPayload::Asap>(view.asap);
+        payload.set<GpioReadConfigPayload::RisingEdge>(view.rising_edge);
+        payload.set<GpioReadConfigPayload::FallingEdge>(view.falling_edge);
+        payload.set<GpioReadConfigPayload::Pull>(view.pull);
+        payload.set<GpioReadConfigPayload::PeriodMs>(view.period_ms);
+
+        utility::assert_debug(cursor == dst.data() + dst.size());
+        return SerializeResult::kSuccess;
+    }
+
+    SerializeResult write_gpio_analog_value(
+        uint8_t channel_index, const data::GpioAnalogDataView& view) noexcept {
+        utility::assert_debug(channel_index < (1U << GpioHeader::ChannelIndex::kBitWidth));
+        const std::size_t required =
+            required_gpio_size(FieldId::kGpio, GpioHeader::PayloadEnum::kAnalog);
+        LIBRMCS_VERIFY_LIKELY(required, SerializeResult::kInvalidArgument);
+
+        auto dst = buffer_.allocate(required);
+        LIBRMCS_VERIFY_LIKELY(!dst.empty(), SerializeResult::kBadAlloc);
+        utility::assert_debug(dst.size() == required);
+        std::byte* cursor = dst.data();
+
+        write_field_header(cursor, FieldId::kGpio);
+
+        auto header = GpioHeader::Ref(cursor);
+        cursor += sizeof(GpioHeader);
+        header.set<GpioHeader::PayloadType>(GpioHeader::PayloadEnum::kAnalog);
         header.set<GpioHeader::ChannelIndex>(channel_index);
         header.set<GpioHeader::Timestamped>(false);
 
         auto payload = GpioAnalogPayload::Ref(cursor);
         cursor += sizeof(GpioAnalogPayload);
         payload.set<GpioAnalogPayload::Value>(view.value);
+
+        utility::assert_debug(cursor == dst.data() + dst.size());
+        return SerializeResult::kSuccess;
+    }
+
+    SerializeResult write_gpio_analog_read_config(
+        uint8_t channel_index, const data::GpioReadConfigView& view) noexcept {
+        utility::assert_debug(channel_index < (1U << GpioHeader::ChannelIndex::kBitWidth));
+        LIBRMCS_VERIFY_LIKELY(
+            !view.falling_edge && !view.rising_edge, SerializeResult::kInvalidArgument);
+        LIBRMCS_VERIFY_LIKELY(!view.capture_timestamp, SerializeResult::kInvalidArgument);
+
+        const std::size_t required =
+            required_gpio_size(FieldId::kGpio, GpioHeader::PayloadEnum::kAnalogReadConfig);
+        LIBRMCS_VERIFY_LIKELY(required, SerializeResult::kInvalidArgument);
+
+        auto dst = buffer_.allocate(required);
+        LIBRMCS_VERIFY_LIKELY(!dst.empty(), SerializeResult::kBadAlloc);
+        utility::assert_debug(dst.size() == required);
+        std::byte* cursor = dst.data();
+
+        write_field_header(cursor, FieldId::kGpio);
+
+        auto header = GpioHeader::Ref(cursor);
+        cursor += sizeof(GpioHeader);
+        header.set<GpioHeader::PayloadType>(GpioHeader::PayloadEnum::kAnalogReadConfig);
+        header.set<GpioHeader::ChannelIndex>(channel_index);
+        header.set<GpioHeader::Timestamped>(false);
+
+        auto payload = GpioReadConfigPayload::Ref(cursor);
+        cursor += sizeof(GpioReadConfigPayload);
+        payload.set<GpioReadConfigPayload::Asap>(view.asap);
+        payload.set<GpioReadConfigPayload::RisingEdge>(false);
+        payload.set<GpioReadConfigPayload::FallingEdge>(false);
+        payload.set<GpioReadConfigPayload::Pull>(view.pull);
+        payload.set<GpioReadConfigPayload::PeriodMs>(view.period_ms);
 
         utility::assert_debug(cursor == dst.data() + dst.size());
         return SerializeResult::kSuccess;
@@ -466,20 +411,15 @@ private:
         const std::size_t gpio_header_bytes = sizeof(GpioHeader);
         std::size_t payload_bytes = 0;
         switch (payload) {
-        case GpioHeader::PayloadEnum::kDigitalWriteLow:
-        case GpioHeader::PayloadEnum::kDigitalWriteHigh: payload_bytes = 0; break;
-        case GpioHeader::PayloadEnum::kDigitalReadResultLow:
-        case GpioHeader::PayloadEnum::kDigitalReadResultHigh:
+        case GpioHeader::PayloadEnum::kDigitalLow:
+        case GpioHeader::PayloadEnum::kDigitalHigh:
             payload_bytes = timestamped ? sizeof(GpioDigitalReadTimestampPayload) : 0;
             break;
-        case GpioHeader::PayloadEnum::kDigitalRead:
-        case GpioHeader::PayloadEnum::kAnalogRead:
+        case GpioHeader::PayloadEnum::kDigitalReadConfig:
+        case GpioHeader::PayloadEnum::kAnalogReadConfig:
             payload_bytes = sizeof(GpioReadConfigPayload);
             break;
-        case GpioHeader::PayloadEnum::kAnalogWrite:
-        case GpioHeader::PayloadEnum::kAnalogReadResult:
-            payload_bytes = sizeof(GpioAnalogPayload);
-            break;
+        case GpioHeader::PayloadEnum::kAnalog: payload_bytes = sizeof(GpioAnalogPayload); break;
         default: return 0;
         }
 

--- a/firmware/c_board/app/src/gpio/gpio.hpp
+++ b/firmware/c_board/app/src/gpio/gpio.hpp
@@ -211,7 +211,7 @@ private:
 
         auto& serializer = usb::get_serializer();
         core::utility::assert_debug(
-            serializer.write_gpio_digital_read_result(
+            serializer.write_gpio_digital_value(
                 channel_index, {.high = high, .timestamp_quarter_us = timestamp_to_publish})
             != core::protocol::Serializer::SerializeResult::kInvalidArgument);
     }

--- a/firmware/c_board/app/src/usb/vendor.hpp
+++ b/firmware/c_board/app/src/usb/vendor.hpp
@@ -106,74 +106,82 @@ private:
         session_established_ = true;
     }
 
-    void can_deserialized_callback(
+    bool can_deserialized_callback(
         core::protocol::FieldId id, const data::CanDataView& data) override {
         if (!session_established_)
-            return;
+            return true;
         switch (id) {
-        case data::DataId::kCan1: can::can1->handle_downlink(data); break;
-        case data::DataId::kCan2: can::can2->handle_downlink(data); break;
-        default: core::utility::assert_failed_always();
+        case data::DataId::kCan1: can::can1->handle_downlink(data); return true;
+        case data::DataId::kCan2: can::can2->handle_downlink(data); return true;
+        default: return false;
         }
     }
 
-    void uart_deserialized_callback(
+    bool uart_deserialized_callback(
         core::protocol::FieldId id, const data::UartDataView& data) override {
         if (!session_established_)
-            return;
+            return true;
         switch (id) {
-        case data::DataId::kUart1: uart::uart1->handle_downlink(data); break;
-        case data::DataId::kUart2: uart::uart2->handle_downlink(data); break;
-        default: core::utility::assert_failed_always();
+        case data::DataId::kUart1: uart::uart1->handle_downlink(data); return true;
+        case data::DataId::kUart2: uart::uart2->handle_downlink(data); return true;
+        default: return false;
         }
     }
 
-    void gpio_digital_data_deserialized_callback(
+    bool gpio_digital_data_deserialized_callback(
         uint8_t channel_index, const data::GpioDigitalDataView& data) override {
         if (!session_established_)
-            return;
+            return true;
+        if (data.timestamp_quarter_us.has_value())
+            return false;
         if (channel_index >= kGpioChannelCount)
-            return;
+            return false;
 
         const auto& gpio = spec::c_board::kGpioDescriptors[channel_index];
         if (!gpio.supports(spec::GpioCapability::kDigitalWrite))
-            return;
+            return false;
 
         gpio::gpio->handle_digital_write(channel_index, data);
+        return true;
     }
 
-    void gpio_analog_data_deserialized_callback(
+    bool gpio_analog_data_deserialized_callback(
         uint8_t channel_index, const data::GpioAnalogDataView& data) override {
         if (!session_established_)
-            return;
+            return true;
         if (channel_index >= kGpioChannelCount)
-            return;
+            return false;
 
         const auto& gpio = spec::c_board::kGpioDescriptors[channel_index];
         if (!gpio.supports(spec::GpioCapability::kAnalogWrite))
-            return;
+            return false;
 
         gpio::gpio->handle_analog_write(channel_index, data);
+        return true;
     }
 
-    void gpio_digital_read_config_deserialized_callback(
+    bool gpio_digital_read_config_deserialized_callback(
         uint8_t channel_index, const data::GpioReadConfigView& data) override {
         if (!session_established_)
-            return;
+            return true;
         if (channel_index >= kGpioChannelCount)
-            return;
+            return false;
 
         const auto& gpio = spec::c_board::kGpioDescriptors[channel_index];
         if (!data.supported(gpio))
-            return;
+            return false;
 
         gpio::gpio->handle_digital_read(channel_index, data);
+        return true;
     }
 
-    void gpio_analog_read_config_deserialized_callback(
+    bool gpio_analog_read_config_deserialized_callback(
         uint8_t channel_index, const data::GpioReadConfigView& data) override {
+        if (!session_established_)
+            return true;
         (void)channel_index;
         (void)data;
+        return false;
     }
 
     void accelerometer_deserialized_callback(const data::AccelerometerDataView& data) override {

--- a/firmware/rmcs_board/app/src/gpio/gpio.hpp
+++ b/firmware/rmcs_board/app/src/gpio/gpio.hpp
@@ -309,7 +309,7 @@ private:
 
         auto& serializer = usb::get_serializer();
         core::utility::assert_debug(
-            serializer.write_gpio_digital_read_result(
+            serializer.write_gpio_digital_value(
                 channel_index, {.high = high, .timestamp_quarter_us = timestamp_to_publish})
             != core::protocol::Serializer::SerializeResult::kInvalidArgument);
     }

--- a/firmware/rmcs_board/app/src/usb/vendor.hpp
+++ b/firmware/rmcs_board/app/src/usb/vendor.hpp
@@ -111,82 +111,90 @@ private:
         session_established_ = true;
     }
 
-    void can_deserialized_callback(
+    bool can_deserialized_callback(
         core::protocol::FieldId id, const data::CanDataView& data) override {
         if (!session_established_)
-            return;
+            return true;
         switch (id) {
-        case data::DataId::kCan0: can::can_array[0]->handle_downlink(data); break;
-        case data::DataId::kCan1: can::can_array[1]->handle_downlink(data); break;
-        case data::DataId::kCan2: can::can_array[2]->handle_downlink(data); break;
-        case data::DataId::kCan3: can::can_array[3]->handle_downlink(data); break;
-        default: core::utility::assert_failed_always();
+        case data::DataId::kCan0: can::can_array[0]->handle_downlink(data); return true;
+        case data::DataId::kCan1: can::can_array[1]->handle_downlink(data); return true;
+        case data::DataId::kCan2: can::can_array[2]->handle_downlink(data); return true;
+        case data::DataId::kCan3: can::can_array[3]->handle_downlink(data); return true;
+        default: return false;
         }
     }
 
-    void uart_deserialized_callback(
+    bool uart_deserialized_callback(
         core::protocol::FieldId id, const data::UartDataView& data) override {
         if (!session_established_)
-            return;
+            return true;
         switch (id) {
-        case data::DataId::kUart0: uart::uart_array[0]->handle_downlink(data); break;
-        case data::DataId::kUart1: uart::uart_array[1]->handle_downlink(data); break;
+        case data::DataId::kUart0: uart::uart_array[0]->handle_downlink(data); return true;
+        case data::DataId::kUart1: uart::uart_array[1]->handle_downlink(data); return true;
 #ifdef BOARD_UART2
-        case data::DataId::kUart2: uart::uart_array[2]->handle_downlink(data); break;
+        case data::DataId::kUart2: uart::uart_array[2]->handle_downlink(data); return true;
 #endif
 #ifdef BOARD_UART3
-        case data::DataId::kUart3: uart::uart_array[3]->handle_downlink(data); break;
+        case data::DataId::kUart3: uart::uart_array[3]->handle_downlink(data); return true;
 #endif
-        default: core::utility::assert_failed_always();
+        default: return false;
         }
     }
 
-    void gpio_digital_data_deserialized_callback(
+    bool gpio_digital_data_deserialized_callback(
         uint8_t channel_index, const data::GpioDigitalDataView& data) override {
         if (!session_established_)
-            return;
+            return true;
+        if (data.timestamp_quarter_us.has_value())
+            return false;
         if (channel_index >= board::spec::kGpioDescriptors.size())
-            return;
+            return false;
 
         const auto& gpio_descriptor = board::spec::kGpioDescriptors[channel_index];
         if (!gpio_descriptor.supports(spec::GpioCapability::kDigitalWrite))
-            return;
+            return false;
 
         gpio::gpio->handle_digital_write(channel_index, data);
+        return true;
     }
 
-    void gpio_analog_data_deserialized_callback(
+    bool gpio_analog_data_deserialized_callback(
         uint8_t channel_index, const data::GpioAnalogDataView& data) override {
         if (!session_established_)
-            return;
+            return true;
         if (channel_index >= board::spec::kGpioDescriptors.size())
-            return;
+            return false;
 
         const auto& gpio_descriptor = board::spec::kGpioDescriptors[channel_index];
         if (!gpio_descriptor.supports(spec::GpioCapability::kAnalogWrite))
-            return;
+            return false;
 
         gpio::gpio->handle_analog_write(channel_index, data);
+        return true;
     }
 
-    void gpio_digital_read_config_deserialized_callback(
+    bool gpio_digital_read_config_deserialized_callback(
         uint8_t channel_index, const data::GpioReadConfigView& data) override {
         if (!session_established_)
-            return;
+            return true;
         if (channel_index >= board::spec::kGpioDescriptors.size())
-            return;
+            return false;
 
         const auto& gpio_descriptor = board::spec::kGpioDescriptors[channel_index];
         if (!data.supported(gpio_descriptor))
-            return;
+            return false;
 
         gpio::gpio->handle_digital_read(channel_index, data);
+        return true;
     }
 
-    void gpio_analog_read_config_deserialized_callback(
+    bool gpio_analog_read_config_deserialized_callback(
         uint8_t channel_index, const data::GpioReadConfigView& data) override {
+        if (!session_established_)
+            return true;
         (void)channel_index;
         (void)data;
+        return false;
     }
 
     void accelerometer_deserialized_callback(const data::AccelerometerDataView& data) override {

--- a/host/src/protocol/handler.cpp
+++ b/host/src/protocol/handler.cpp
@@ -61,52 +61,70 @@ public:
 
     PacketBuilder start_transmit() { return PacketBuilder{transport_.get()}; }
 
-    void can_deserialized_callback(
+    bool can_deserialized_callback(
         core::protocol::FieldId id, const data::CanDataView& data) override {
         if (!session_established())
-            return;
-        if (!callback_.can_receive_callback(id, data))
+            return true;
+        if (!callback_.can_receive_callback(id, data)) {
             logging::get_logger().error("Unexpected can field id: ", static_cast<int>(id));
+            return false;
+        }
+        return true;
     }
 
-    void uart_deserialized_callback(
+    bool uart_deserialized_callback(
         core::protocol::FieldId id, const data::UartDataView& data) override {
         if (!session_established())
-            return;
-        if (!callback_.uart_receive_callback(id, data))
+            return true;
+        if (!callback_.uart_receive_callback(id, data)) {
             logging::get_logger().error("Unexpected uart field id: ", static_cast<int>(id));
+            return false;
+        }
+        return true;
     }
 
-    void gpio_digital_data_deserialized_callback(
+    bool gpio_digital_data_deserialized_callback(
         uint8_t channel_index, const data::GpioDigitalDataView& data) override {
         if (!session_established())
-            return;
-        if (!callback_.gpio_digital_read_result_callback(channel_index, data))
+            return true;
+        if (!callback_.gpio_digital_read_result_callback(channel_index, data)) {
             logging::get_logger().error(
                 "Unexpected gpio channel index: ", static_cast<int>(channel_index));
+            return false;
+        }
+        return true;
     }
 
-    void gpio_analog_data_deserialized_callback(
+    bool gpio_analog_data_deserialized_callback(
         uint8_t channel_index, const data::GpioAnalogDataView& data) override {
         if (!session_established())
-            return;
-        if (!callback_.gpio_analog_read_result_callback(channel_index, data))
+            return true;
+        if (!callback_.gpio_analog_read_result_callback(channel_index, data)) {
             logging::get_logger().error(
                 "Unexpected gpio channel index: ", static_cast<int>(channel_index));
+            return false;
+        }
+        return true;
     }
 
-    void gpio_digital_read_config_deserialized_callback(
+    bool gpio_digital_read_config_deserialized_callback(
         uint8_t channel_index, const data::GpioReadConfigView& data) override {
+        if (!session_established())
+            return true;
         (void)channel_index;
         (void)data;
         logging::get_logger().error("Unexpected gpio digital read config field in uplink");
+        return false;
     }
 
-    void gpio_analog_read_config_deserialized_callback(
+    bool gpio_analog_read_config_deserialized_callback(
         uint8_t channel_index, const data::GpioReadConfigView& data) override {
+        if (!session_established())
+            return true;
         (void)channel_index;
         (void)data;
         logging::get_logger().error("Unexpected gpio analog read config field in uplink");
+        return false;
     }
 
     void accelerometer_deserialized_callback(const data::AccelerometerDataView& data) override {
@@ -295,7 +313,9 @@ struct PacketBuilderImpl {
 
     [[nodiscard]] bool write_gpio_digital_data(
         uint8_t channel_index, const data::GpioDigitalDataView& view) noexcept {
-        return process_result(serializer_.write_gpio_digital_data(channel_index, view));
+        if (view.timestamp_quarter_us.has_value()) [[unlikely]]
+            return false;
+        return process_result(serializer_.write_gpio_digital_value(channel_index, view));
     }
 
     [[nodiscard]] bool write_gpio_digital_read_config(
@@ -305,7 +325,7 @@ struct PacketBuilderImpl {
 
     [[nodiscard]] bool write_gpio_analog_data(
         uint8_t channel_index, const data::GpioAnalogDataView& view) noexcept {
-        return process_result(serializer_.write_gpio_analog_data(channel_index, view));
+        return process_result(serializer_.write_gpio_analog_value(channel_index, view));
     }
 
     [[nodiscard]] bool write_imu_accelerometer(const data::AccelerometerDataView& view) noexcept {


### PR DESCRIPTION
- Propagate deserializer callback failures for CAN, UART, and GPIO so unexpected DataId values, channel indexes, and unsupported GPIO configurations abort the current transfer instead of being logged and ignored.
- Collapse GPIO write and read-result packets into shared value payloads and rename GPIO config payload enums to reflect protocol semantics. Keep timestamped digital samples for uplink reads, but reject timestamped digital writes on host and firmware downlink paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 变更概述

本次PR修复了librmcs库中的协议处理方式，并简化了GPIO有效负载结构。主要涉及两个方面的改进：

### 1. 反序列化器中的错误传播

#### 核心库更新（`deserializer.cpp` 和 `deserializer.hpp`）
- **CAN和UART字段处理**：修改了 `process_can_field` 和 `process_uart_field` 方法，使其不再无条件返回 `true`，而是将回调的返回值（`can_deserialized_callback` / `uart_deserialized_callback`）直接作为结果返回，从而使无效的DataId值或错误的处理能够正确地终止当前传输。

- **GPIO字段处理**：调整了 `process_gpio_field` 的分支逻辑：
  - 数字和模拟数据分支：新增回调返回值检查，回调失败时返回 `false`
  - 读配置分支：对模拟读配置添加了约束检查（若包含 `capture_timestamp` 标志则视为失败），两类读配置的回调均以返回值决定成败

- **方法签名更新**：将六个关键回调从 `virtual void` 改为 `[[nodiscard]] virtual bool`：
  - `can_deserialized_callback`
  - `uart_deserialized_callback`  
  - `gpio_digital_data_deserialized_callback`
  - `gpio_analog_data_deserialized_callback`
  - `gpio_digital_read_config_deserialized_callback`
  - `gpio_analog_read_config_deserialized_callback`

#### 固件端实现更新
**C板固件** (`firmware/c_board/app/src/usb/vendor.hpp`)：
- CAN和UART回调：在未建立会话时返回 `true`，匹配失败时返回 `false`（替代原有的assert断言）
- GPIO数字/模拟写回调：新增对通道越界和能力支持的检查，返回失败状态而非无返回值
- GPIO数字写回调：新增对时间戳的检查，若 `timestamp_quarter_us` 存在则返回 `false`
- GPIO读配置回调：改为明确返回 `bool` 值

**RMCS板固件** (`firmware/rmcs_board/app/src/usb/vendor.hpp`)：
- 类似的回调改造，使错误条件能够被正确传播而非忽略

**主机端处理** (`host/src/protocol/handler.cpp`)：
- 反序列化回调：当会话未建立时返回 `true`，当上层拒绝处理时记录错误并返回 `false`
- GPIO数字/模拟数据结果回调：新增布尔返回值以反映是否接受该字段
- GPIO读配置回调：改为在记录异常后返回 `false`

### 2. GPIO有效负载结构简化

#### 协议定义修改 (`protocol.hpp`)
- **PayloadEnum重组**：将原有的 `kDigitalWriteLow`、`kDigitalWriteHigh`、`kDigitalRead`、`kAnalogRead`、`kDigitalReadResultLow` 等枚举项重新组织为：
  - `kDigitalLow` 和 `kDigitalHigh`（用于数字读写值）
  - `kAnalog`（用于模拟数据）
  - `kDigitalReadConfig` 和 `kAnalogReadConfig`（用于读配置）
- 移除了原有的读结果专用枚举值

#### 序列化器更新 (`serializer.hpp`)
- **方法重命名**：
  - `write_gpio_digital_data` → `write_gpio_digital_value`（支持可选的 `timestamp_quarter_us` 字段）
  - `write_gpio_analog_data` → `write_gpio_analog_value`
- **读配置序列化调整**：
  - `write_gpio_digital_read_config` 现在设置 `kDigitalReadConfig` 有效负载类型
  - `write_gpio_analog_read_config` 现在设置 `kAnalogReadConfig` 有效负载类型
- **移除的方法**：删除了 `write_gpio_digital_read_result` 和 `write_gpio_analog_read_result`
- **Size计算更新**：`required_gpio_size` 的switch表已适配新的有效负载枚举值

#### 固件端序列化调用更新
**C板** (`firmware/c_board/app/src/gpio/gpio.hpp`)：
- `publish_digital_input_sample` 改用 `write_gpio_digital_value` 替代 `write_gpio_digital_read_result`

**RMCS板** (`firmware/rmcs_board/app/src/gpio/gpio.hpp`)：
- 同样更新了数字输入采样的序列化调用

**主机端** (`host/src/protocol/handler.cpp`)：
- PacketBuilder实现中更新了GPIO数据写入的调用路径
- `write_gpio_digital_data` 新增对时间戳的检查（若存在则拒绝）

## 总体影响

这些改动提高了协议实现的健壮性，确保无效或意外的数据能够导致传输失败而非被无声忽略，使调试更加便利，并防止畸形消息导致的潜在问题。GPIO有效负载的整合减少了冗余，使协议结构更加清晰。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->